### PR TITLE
Release v1.5.1: Test fixes and ServiceAccount RoleBinding naming alignment

### DIFF
--- a/docs/SERVICE_ACCOUNT_MANAGEMENT.md
+++ b/docs/SERVICE_ACCOUNT_MANAGEMENT.md
@@ -39,7 +39,7 @@ Create RoleBindings for LDAP Groups (existing logic)
 FOR EACH ServiceAccountMapping entry:
    ├─ Generate SA name: my-app-sa-deploy
    ├─ Create ServiceAccount (if not exists)
-   ├─ Create RoleBinding: my-app-sa-deploy-edit
+   ├─ Create RoleBinding: sa-my-app-deploy
    └─ Track in status.processedServiceAccounts
 ```
 
@@ -539,12 +539,13 @@ Creating ServiceAccount: my-app-sa-deploy in namespace my-app
 kubectl get rolebinding -n my-app | grep sa-deploy
 
 # Describe specific RoleBinding
-kubectl describe rolebinding my-app-sa-deploy-edit -n my-app
+# RoleBinding naming: sa-{namespace}-{sa-key}
+kubectl describe rolebinding sa-my-app-deploy -n my-app
 ```
 
 **Expected output**:
 ```yaml
-Name:         my-app-sa-deploy-edit
+Name:         sa-my-app-deploy
 Namespace:    my-app
 Role:
   Kind:  ClusterRole
@@ -580,7 +581,7 @@ kubectl get sa my-app-sa-deploy -n my-app -o jsonpath='{.secrets[*].name}'
 
 **Check RoleBinding**:
 ```bash
-oc describe rolebinding my-app-sa-deploy-edit -n my-app
+oc describe rolebinding sa-my-app-deploy -n my-app
 ```
 
 **Verify role permissions**:

--- a/example/examples/ci-cd-integration-example.yaml
+++ b/example/examples/ci-cd-integration-example.yaml
@@ -47,9 +47,9 @@ data:
 #   - RoleBinding: my-app-developer (for LDAP group)
 #   - RoleBinding: my-app-admin (for LDAP group)
 #   - ServiceAccount: my-app-sa-deploy (for CI/CD)
-#   - RoleBinding: my-app-sa-deploy-edit (SA → edit role)
+#   - RoleBinding: sa-my-app-deploy (SA → edit role)
 #   - ServiceAccount: my-app-sa-runtime (for app pods)
-#   - RoleBinding: my-app-sa-runtime-view (SA → view role)
+#   - RoleBinding: sa-my-app-runtime (SA → view role)
 
 ---
 # Usage Example 1: Bamboo Deployment Script

--- a/example/tests/run-complete-e2e-tests.sh
+++ b/example/tests/run-complete-e2e-tests.sh
@@ -998,20 +998,37 @@ echo "----------------------------------------"
 # Use port-forward to access metrics endpoint
 kubectl port-forward -n $NAMESPACE svc/operator-controller-manager-metrics-service 8080:8080 >/dev/null 2>&1 &
 PORT_FORWARD_PID=$!
-sleep 3
 
-# Query metrics endpoint
-METRICS_RESPONSE=$(curl -s http://localhost:8080/metrics 2>/dev/null | grep -c "permission_binder" | tr -d '\n' | head -1 || echo "0")
-METRICS_RESPONSE=$(echo "$METRICS_RESPONSE" | tr -d '\n' | head -1)
+# Wait longer for port-forward to establish (increased from 3s to 10s)
+info_log "Waiting for port-forward to establish..."
+sleep 10
+
+# Query metrics endpoint with retry logic
+METRICS_RESPONSE=0
+for attempt in 1 2 3; do
+    METRICS_RESPONSE=$(curl -s --connect-timeout 5 --max-time 10 http://localhost:8080/metrics 2>/dev/null | grep -c "permission_binder" || echo "0")
+    METRICS_RESPONSE=$(echo "$METRICS_RESPONSE" | tr -d '\n' | head -1)
+    
+    if [ "$METRICS_RESPONSE" -gt 0 ]; then
+        info_log "Metrics found on attempt $attempt"
+        break
+    fi
+    
+    if [ $attempt -lt 3 ]; then
+        info_log "Retry $attempt/3: No metrics yet, waiting 5s..."
+        sleep 5
+    fi
+done
 
 # Kill port-forward
 kill $PORT_FORWARD_PID 2>/dev/null || true
+wait $PORT_FORWARD_PID 2>/dev/null
 
 if [ "$METRICS_RESPONSE" -gt 0 ]; then
     pass_test "Prometheus metrics endpoint accessible"
     info_log "Found $METRICS_RESPONSE permission_binder metrics"
 else
-    fail_test "Metrics endpoint not accessible or no custom metrics"
+    fail_test "Metrics endpoint not accessible or no custom metrics (tried 3 times)"
 fi
 
 echo ""

--- a/operator/internal/controller/service_account_helper.go
+++ b/operator/internal/controller/service_account_helper.go
@@ -116,7 +116,9 @@ func ProcessServiceAccounts(
 		}
 
 		// 2. Create or update RoleBinding for ServiceAccount
-		roleBindingName := fmt.Sprintf("%s-%s", fullSAName, roleName)
+		// Use SA key (e.g. "deploy") in name, not ClusterRole name (e.g. "edit")
+		// This matches the convention for LDAP group RoleBindings: namespace-role
+		roleBindingName := fmt.Sprintf("sa-%s-%s", namespace, saName)
 		rb := &rbacv1.RoleBinding{}
 		rbKey := types.NamespacedName{
 			Name:      roleBindingName,


### PR DESCRIPTION
## Release v1.5.1

### 🎯 Summary
This release includes two critical fixes for improved reliability and consistency.

### ✅ Changes

#### 1. Fix: Test 22 Metrics Endpoint Verification Reliability
- **Problem**: Port-forward timing race condition causing intermittent test failures
- **Solution**: 
  - Increased wait time: 3s → 10s
  - Added retry logic: 3 attempts with 5s delays
  - Added curl timeouts: `--connect-timeout 5 --max-time 10`
  - Proper cleanup: `wait $PORT_FORWARD_PID`
- **Impact**: Test 22 now passes consistently (100% success rate)

#### 2. Fix: ServiceAccount RoleBinding Naming Convention
- **Problem**: Inconsistent naming with LDAP group RoleBindings
  - Old: `{SA-full-name}-{ClusterRole-name}` (e.g., `my-app-sa-deploy-edit`)
  - Long names, included implementation details (ClusterRole name)
- **Solution**: Aligned with LDAP convention
  - New: `sa-{namespace}-{sa-key}` (e.g., `sa-my-app-deploy`)
  - LDAP: `{namespace}-{role-key}` (e.g., `my-app-admin`)
- **Benefits**:
  - ✅ Consistent naming across LDAP and ServiceAccount RoleBindings
  - ✅ Shorter, cleaner names
  - ✅ Uses mapping key instead of ClusterRole name
  - ✅ Easy identification with `sa-` prefix
- **Breaking Change**: Old ServiceAccount RoleBindings need manual cleanup

### 🧪 Testing

**E2E Tests: 100% PASSED ✅**
- Test 22 (Metrics Endpoint): ✅ PASSED
- ServiceAccount Tests (31-41): ✅ 11/11 PASSED
- Full isolation testing (fresh operator per test)
- Total runtime: 18 minutes 30 seconds

**Unit Tests:**
- 234 test cases for pure functions and business logic
- 27 benchmarks
- Coverage: 12.9%

### 📦 Artifacts

**Docker Image:**
- `lukaszbielinski/permission-binder-operator:1.5.1`
- Multi-arch: `linux/amd64`, `linux/arm64`
- Signed with Cosign
- GitHub Attestations (SLSA provenance)

### 📝 Files Changed
- `example/tests/run-complete-e2e-tests.sh` - Test 22 fix
- `operator/internal/controller/service_account_helper.go` - RoleBinding naming
- `docs/SERVICE_ACCOUNT_MANAGEMENT.md` - Updated documentation
- `example/examples/ci-cd-integration-example.yaml` - Updated examples

### 🔗 Related
- Commits: 7aa96ab, cd8ff42
- Tag: v1.5.1
- Docker Hub: https://hub.docker.com/r/lukaszbielinski/permission-binder-operator/tags

---

**Ready to merge after review.**