### PR TITLE
feat(networkpolicy): migrate to go-git and return to distroless

### DIFF
--- a/example/deployment/operator-deployment.yaml
+++ b/example/deployment/operator-deployment.yaml
@@ -755,7 +755,7 @@ spec:
         # Production: use specific version (v1.6.2)
         # Development: use latest tag with Always pull policy
         image: lukaszbielinski/permission-binder-operator:v1.6.2
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         env:
         # Enable debug mode to see detailed reconciliation trigger logging
         # Set to "true" or "1" to enable, "false" or "0" to disable (default: disabled)

--- a/example/deployment/operator-deployment.yaml
+++ b/example/deployment/operator-deployment.yaml
@@ -755,7 +755,7 @@ spec:
         # Production: use specific version (v1.6.2)
         # Development: use latest tag with Always pull policy
         image: lukaszbielinski/permission-binder-operator:v1.6.2
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         env:
         # Enable debug mode to see detailed reconciliation trigger logging
         # Set to "true" or "1" to enable, "false" or "0" to disable (default: disabled)

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -13,7 +13,6 @@ RUN go mod download
 
 # Copy the go source
 COPY cmd/main.go cmd/main.go
-COPY cmd/git-askpass-helper/ cmd/git-askpass-helper/
 COPY api/ api/
 COPY internal/controller/ internal/controller/
 
@@ -22,18 +21,18 @@ COPY internal/controller/ internal/controller/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go && \
-    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o git-askpass-helper cmd/git-askpass-helper/main.go
+# Note: git-askpass-helper is no longer needed - go-git uses BasicAuth directly
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
-# Use alpine as base image to include git for NetworkPolicy GitOps operations
-# Alpine is minimal and secure, and includes git which is required for cloning repositories
-FROM alpine:3.19
-RUN apk --no-cache add ca-certificates git
+# Use distroless static image - pure Go implementation (go-git) doesn't need git binary
+# distroless/static:nonroot provides maximum security (no shell, no package manager, minimal attack surface)
+# go-git is a pure Go library, so we don't need git binary or any system dependencies
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
+# Copy manager binary (statically linked Go binary)
 COPY --from=builder /workspace/manager .
-COPY --from=builder /workspace/git-askpass-helper /usr/local/bin/git-askpass-helper
-# Create non-root user (65532:65532 matches distroless nonroot user)
-RUN addgroup -g 65532 nonroot && adduser -D -u 65532 -G nonroot nonroot
+# Note: git-askpass-helper is no longer needed - go-git uses BasicAuth directly
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -15,6 +15,7 @@ require (
 	k8s.io/client-go v0.32.0
 	sigs.k8s.io/controller-runtime v0.19.0
 	sigs.k8s.io/kustomize/api v0.20.1
+	sigs.k8s.io/yaml v1.5.0
 )
 
 require (
@@ -121,5 +122,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.20.1 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
-	sigs.k8s.io/yaml v1.5.0 // indirect
 )

--- a/operator/internal/controller/networkpolicy/git_security.go
+++ b/operator/internal/controller/networkpolicy/git_security.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networkpolicy
+
+import (
+	"regexp"
+	"strings"
+)
+
+// sanitizeError removes sensitive information (tokens, passwords, credentials) from error messages.
+// This prevents credential leakage in logs and error messages.
+func sanitizeError(err error, credentials *gitCredentials) error {
+	if err == nil {
+		return nil
+	}
+
+	errMsg := err.Error()
+
+	// Remove token if present
+	if credentials != nil && credentials.token != "" {
+		errMsg = strings.ReplaceAll(errMsg, credentials.token, "[REDACTED]")
+		// Also replace common token patterns
+		errMsg = regexp.MustCompile(`(?i)(token|bearer|private-token|authorization)[\s:=]+[a-zA-Z0-9_-]{20,}`).ReplaceAllString(errMsg, "$1 [REDACTED]")
+	}
+
+	// Remove username if present (might be sensitive)
+	if credentials != nil && credentials.username != "" {
+		// Only redact if it's not a default username
+		if credentials.username != "permission-binder-operator" {
+			errMsg = strings.ReplaceAll(errMsg, credentials.username, "[REDACTED]")
+		}
+	}
+
+	// Remove common credential patterns from URLs
+	errMsg = regexp.MustCompile(`://[^:]+:[^@]+@`).ReplaceAllString(errMsg, "://[REDACTED]:[REDACTED]@")
+	errMsg = regexp.MustCompile(`(token|password|secret|key)[\s:=]+[a-zA-Z0-9_-]{10,}`).ReplaceAllStringFunc(errMsg, func(match string) string {
+		parts := regexp.MustCompile(`[\s:=]+`).Split(match, 2)
+		if len(parts) == 2 {
+			return parts[0] + " [REDACTED]"
+		}
+		return match
+	})
+
+	return &sanitizedError{
+		original: err,
+		message:  errMsg,
+	}
+}
+
+// sanitizeString removes sensitive information from strings (for logging).
+func sanitizeString(s string, credentials *gitCredentials) string {
+	if credentials == nil {
+		return s
+	}
+
+	result := s
+
+	// Remove token if present
+	if credentials.token != "" {
+		result = strings.ReplaceAll(result, credentials.token, "[REDACTED]")
+		// Also replace common token patterns
+		result = regexp.MustCompile(`(?i)(token|bearer|private-token|authorization)[\s:=]+[a-zA-Z0-9_-]{20,}`).ReplaceAllString(result, "$1 [REDACTED]")
+	}
+
+	// Remove username if present (might be sensitive)
+	if credentials.username != "" && credentials.username != "permission-binder-operator" {
+		result = strings.ReplaceAll(result, credentials.username, "[REDACTED]")
+	}
+
+	// Remove common credential patterns from URLs
+	result = regexp.MustCompile(`://[^:]+:[^@]+@`).ReplaceAllString(result, "://[REDACTED]:[REDACTED]@")
+	result = regexp.MustCompile(`(token|password|secret|key)[\s:=]+[a-zA-Z0-9_-]{10,}`).ReplaceAllStringFunc(result, func(match string) string {
+		parts := regexp.MustCompile(`[\s:=]+`).Split(match, 2)
+		if len(parts) == 2 {
+			return parts[0] + " [REDACTED]"
+		}
+		return match
+	})
+
+	return result
+}
+
+// sanitizedError wraps an error with a sanitized message.
+type sanitizedError struct {
+	original error
+	message  string
+}
+
+func (e *sanitizedError) Error() string {
+	return e.message
+}
+
+func (e *sanitizedError) Unwrap() error {
+	return e.original
+}
+

--- a/operator/internal/controller/networkpolicy/reconciliation_cleanup.go
+++ b/operator/internal/controller/networkpolicy/reconciliation_cleanup.go
@@ -163,12 +163,16 @@ func ProcessRemovedNamespaces(
 
 		pr, err := createPullRequest(ctx, provider, apiBaseURL, gitRepo.URL, branchName, baseBranch, prTitle, prDescription, nil, credentials, tlsVerify)
 		if err != nil {
-			logger.Error(err, "Failed to create removal PR",
+			// Sanitize error and URLs to prevent token leakage
+			sanitizedErr := sanitizeError(err, credentials)
+			sanitizedRepoURL := sanitizeString(gitRepo.URL, credentials)
+			sanitizedAPIBaseURL := sanitizeString(apiBaseURL, credentials)
+			logger.Error(sanitizedErr, "Failed to create removal PR",
 				"namespace", namespace,
 				"branch", branchName,
 				"provider", provider,
-				"apiBaseURL", apiBaseURL,
-				"repoURL", gitRepo.URL)
+				"apiBaseURL", sanitizedAPIBaseURL,
+				"repoURL", sanitizedRepoURL)
 			os.RemoveAll(tmpDir)
 			continue
 		}


### PR DESCRIPTION
## 🚀 Major Architecture Update: go-git Migration & Distroless Return

### 📋 Summary
Complete migration from git CLI to pure Go implementation (`go-git/v5`) and return to `distroless/static:nonroot` base image for maximum security.

---

## ✨ Key Changes

### 🔒 Security Improvements
- **Migration to go-git/v5**: Eliminated dependency on external `git` binary
- **Return to distroless**: Base image changed to `gcr.io/distroless/static:nonroot`
- **Token Sanitization**: New `git_security.go` module prevents credential leakage
- **In-Memory Credentials**: Using `BasicAuth` (no environment variables, no external helpers)

### 🐛 Bug Fixes
- Fixed branch checkout handling for existing branches in go-git
- Improved error messages and logging

### 📦 Performance
- **Image Size**: 96.5MB → 83.2MB (13.5% reduction)
- **Attack Surface**: Minimal (no shell, no git binary, no package manager)
- **Startup Time**: Maintained (< 5 seconds)

---

## 🧪 Testing

### ✅ E2E Tests: **17/17 PASSED (100%)**
- Test 44-60: All NetworkPolicy E2E scenarios passing
- Full isolation mode (cleanup + fresh deploy per test)
- Total duration: 34 minutes 45 seconds

### ✅ Verified Functionality
- ✅ Git operations (clone, checkout, commit, push, fetch, reset)
- ✅ PR creation, merge, and state transitions
- ✅ Drift detection and reconciliation
- ✅ Error handling and recovery
- ✅ Metrics and monitoring
- ✅ All NetworkPolicy variants (A, B, C)
- ✅ Edge cases and stress tests

---

## 📝 Technical Details

### Files Changed
```
10 files changed, 688 insertions(+), 436 deletions(-)
- CHANGELOG.md                                       (+166 lines)
- operator/Dockerfile                                (distroless)
- operator/go.mod                                    (go-git v5.16.3)
- operator/internal/controller/networkpolicy/git_api.go
- operator/internal/controller/networkpolicy/git_cli.go (major refactor)
- operator/internal/controller/networkpolicy/git_security.go (NEW, 110 lines)
- operator/internal/controller/networkpolicy/git_cli_test.go
- operator/internal/controller/networkpolicy/reconciliation_cleanup.go
- operator/internal/controller/networkpolicy/reconciliation_single.go
- example/deployment/operator-deployment.yaml
```

### Key Commits
- `785ef64`: Main migration commit (go-git + distroless + token sanitization)
- `4de94d5`: Revert imagePullPolicy to IfNotPresent

---

## 🔍 Security Analysis

**Before (v1.6.1)**:
- Base: Alpine 3.19
- Git: External binary
- Credentials: `git-askpass-helper` binary
- Size: 96.5MB

**After (v1.6.2)**:
- Base: `distroless/static:nonroot`
- Git: Pure Go library (`go-git/v5`)
- Credentials: In-memory `BasicAuth` + sanitization
- Size: 83.2MB

---

## ⚠️ Breaking Changes
**NONE** - Fully backward compatible

---

## 📦 Docker Image
- **Tag**: `v1.6.2`
- **Digest**: `sha256:25e0f609f48b215a17c22d378e52120516943aac521e04332e806455dc3a9f55`
- **Status**: Built, pushed to Docker Hub, and tested ✅

---

## 🎯 Checklist
- [x] Code compiles without warnings
- [x] All unit tests passing
- [x] All E2E tests passing (17/17, 100%)
- [x] Linter clean
- [x] Docker image built and pushed
- [x] CHANGELOG.md updated
- [x] No breaking changes
- [x] Security reviewed
- [x] Documentation complete

---

**Ready to merge!** 🚀