### PR TITLE
operator: symmetric ownership enforcement + RECONCILE_NAMESPACES CR scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,15 +243,16 @@ kubectl port-forward -n permissions-binder-operator deployment/operator-controll
 curl -k https://localhost:8443/metrics | grep permission_binder
 ```
 
-**Custom Metrics (15 total):**
+**Custom Metrics (16 total):**
 
-**RBAC Metrics (6):**
+**RBAC Metrics (7):**
 - `permission_binder_missing_clusterrole_total` - Missing ClusterRoles (security!)
 - `permission_binder_orphaned_resources_total` - Orphaned resources count
 - `permission_binder_adoption_events_total` - Successful adoptions
 - `permission_binder_managed_rolebindings_total` - Managed RoleBindings
 - `permission_binder_managed_namespaces_total` - Managed Namespaces
 - `permission_binder_configmap_entries_processed_total` - Processing status
+- `permission_binder_ownership_conflicts_total{resource_type}` - refused resource takeovers due to a live ownership claim by another PermissionBinder; `resource_type`: `namespace` | `rolebinding` | `serviceaccount_rolebinding`
 
 **NetworkPolicy Metrics (5):**
 - `permission_binder_networkpolicy_prs_created_total` - PRs created
@@ -303,6 +304,30 @@ When PermissionBinder is deleted:
 - ✅ Automatic adoption when PermissionBinder is recreated
 
 **Why?** Prevents cascade failures and accidental data loss in production.
+
+### Moving a PermissionBinder between namespaces
+
+The ownership annotations include the CR's namespace, so a CR recreated in a
+different namespace does not silently take over live resources. The supported
+migration path uses SAFE MODE orphaning:
+
+1. Delete the old CR - SAFE MODE annotates all managed **namespaces and group
+   RoleBindings** with `orphaned-at`/`orphaned-by` (nothing is deleted).
+2. Recreate the CR (same name) in the new namespace. If the instance sets
+   `RECONCILE_NAMESPACES`, add the new namespace to the list first (restart
+   required) - otherwise the recreated CR is never reconciled.
+3. On the next reconcile the orphaned resources are re-adopted and re-stamped
+   with the new owner namespace.
+
+> **Warning**: between steps 1 and 3 the orphaned RoleBindings **still grant
+> access** - orphaning never revokes permissions. ServiceAccount resources are
+> **never orphan-annotated** (they are outside SAFE-MODE cleanup): after a
+> namespace move their RoleBindings keep the old-namespace ownership claim,
+> are refused by the ownership gate from the first reconcile (counted in
+> `permission_binder_ownership_conflicts_total`) and excluded from the new
+> CR's status; delete them manually and the operator recreates them under the
+> new owner. The ServiceAccounts themselves also keep the stale claim - log
+> noise only, no functional impact.
 
 ### ClusterRole Validation
 
@@ -426,14 +451,43 @@ cosign verify-attestation \
 
 ### Multi-Instance Isolation (e.g. parallel e2e tests)
 
-By default the operator watches all namespaces. For running multiple isolated
-instances in one cluster, each instance can be scoped to its own namespaces:
+By default the operator watches all namespaces and reconciles every
+PermissionBinder CR. Three env vars scope an instance:
 
-- `WATCH_NAMESPACE` (comma-separated) restricts the operator cache to the listed
-  namespaces. Unset = cluster-wide behavior (unchanged default).
+- `RECONCILE_NAMESPACES` (comma-separated) restricts which PermissionBinder
+  CRs this instance reconciles, by CR namespace. The cache stays cluster-wide,
+  so dynamically created target namespaces remain visible - this is the
+  recommended knob for multi-instance deployments. Unset = reconcile all CRs.
+- `WATCH_NAMESPACE` (comma-separated) restricts the entire operator cache.
+  **Hard requirement**: the list must include the CR's namespace,
+  `spec.configMapNamespace`, every target namespace derived from the
+  whitelist, AND any Secret namespaces referenced by `spec.ldapSecretRef` or
+  `spec.networkPolicy.gitRepository.credentialsSecretRef` - namespace-scoped
+  reads hard-fail with `unknown namespace for the cache` for any unlisted
+  namespace, causing partial reconciliation (namespace created, RoleBindings
+  missing), while cluster-wide label-selector Lists (SAFE-MODE cleanup,
+  metrics) silently omit unlisted namespaces - stale RoleBindings there are
+  never cleaned up. Onboarding a new namespace requires an operator restart
+  with an updated list. Unsuitable for dynamic namespace onboarding; prefer
+  `RECONCILE_NAMESPACES`. Unset = cluster-wide cache (unchanged default).
 - `MANAGED_BY_VALUE` overrides the `permission-binder.io/managed-by` value this
   instance stamps on resources it creates and selects in cluster-wide lists.
-  Give each instance a unique value.
+  **Not isolation by itself**: with a cluster-wide watch and no
+  `RECONCILE_NAMESPACES`, every instance still reconciles every CR and
+  re-stamps other instances' resources with its own value (label flapping,
+  alternating cleanup visibility). Only safe combined with
+  `RECONCILE_NAMESPACES` (or fully disjoint `WATCH_NAMESPACE` sets).
+
+Scoping footguns: when both envs are set, `RECONCILE_NAMESPACES` must be a
+subset of `WATCH_NAMESPACE` (entries outside the cache have no informer and
+their CRs are silently never reconciled; the operator logs a startup warning).
+When narrowing `RECONCILE_NAMESPACES`, make sure every namespace with existing
+CRs stays covered by some instance - a CR carrying the operator finalizer in
+an uncovered namespace becomes undeletable (stuck `Terminating`) until the
+scope is restored or the finalizer is removed manually. Legacy name-only
+resources contested by same-named CRs in different namespaces are claimed by
+whichever instance reconciles first; re-annotate legacy resources explicitly
+before running colliding CR names.
 
 Managed resources are owned per PermissionBinder instance: in addition to
 `permission-binder.io/permission-binder: <cr-name>`, new resources carry
@@ -441,6 +495,13 @@ Managed resources are owned per PermissionBinder instance: in addition to
 annotated the old (name-only) way are still adopted. A PermissionBinder name
 collision between two instances therefore no longer causes cross-instance
 RoleBinding deletion.
+
+Write paths enforce ownership symmetrically with deletion paths: the operator
+refuses to take over (adopt, re-stamp or rewrite) a resource carrying a live
+claim by another PermissionBinder, and counts each refusal in the
+`permission_binder_ownership_conflicts_total{resource_type}` metric.
+Unclaimed resources, legacy name-only-annotated resources and explicitly
+orphaned resources (SAFE-MODE `orphaned-at` marker) remain adoptable.
 
 ### GitOps (ArgoCD)
 

--- a/example/deployment/operator-deployment.yaml
+++ b/example/deployment/operator-deployment.yaml
@@ -319,6 +319,23 @@ spec:
         # - Reasons for skipping reconciliation
         - name: DEBUG_MODE
           value: "false"
+        # Multi-instance scoping envs (all optional; see README "Multi-Instance
+        # Isolation"). The e2e runner injects per-instance values right after
+        # the "env:" line above - keep that line intact.
+        # RECONCILE_NAMESPACES: reconcile only CRs from these namespaces
+        # (cache stays cluster-wide; recommended multi-instance knob).
+        # - name: RECONCILE_NAMESPACES
+        #   value: "permissions-binder-operator"
+        # WATCH_NAMESPACE: scopes the WHOLE cache - must list CR namespace +
+        # configMapNamespace + EVERY target namespace, else cached reads fail
+        # with "unknown namespace for the cache"; unsuitable for dynamic
+        # namespace onboarding.
+        # - name: WATCH_NAMESPACE
+        #   value: "permissions-binder-operator,target-ns-1,target-ns-2"
+        # MANAGED_BY_VALUE: per-instance managed-by stamp; only safe combined
+        # with RECONCILE_NAMESPACES (or disjoint WATCH_NAMESPACE sets).
+        # - name: MANAGED_BY_VALUE
+        #   value: "permission-binder-operator-instance-a"
         startupProbe:
           httpGet:
             path: /readyz

--- a/example/tests/run-tests-full-isolation.sh
+++ b/example/tests/run-tests-full-isolation.sh
@@ -203,12 +203,15 @@ render_instance_manifests() {
         "$SCRIPT_DIR/../deployment/operator-deployment.yaml" \
         | sed -e "/^        env:\$/a\\
         - name: MANAGED_BY_VALUE\\
-          value: \"permission-binder-operator-${INSTANCE}\"" \
+          value: \"permission-binder-operator-${INSTANCE}\"\\
+        - name: RECONCILE_NAMESPACES\\
+          value: \"${NAMESPACE}\"" \
         > "$DEPLOYMENT_MANIFEST"
     # Note: WATCH_NAMESPACE is deliberately NOT set for e2e instances - test
     # namespaces are created dynamically from the whitelist, so a static cache
-    # scope would blind the operator to them. Isolation comes from the unique
-    # MANAGED_BY_VALUE plus the namespace-aware ownership annotations (PR #38).
+    # scope would blind the operator to them. Isolation = unique
+    # MANAGED_BY_VALUE + RECONCILE_NAMESPACES=$NAMESPACE (this instance only
+    # reconciles its own CRs) + the ownership gate on write paths (issue #43).
 
     # ServiceMonitor: unique name and point namespaceSelector at this instance's
     # operator namespace. It stays in the shared "monitoring" namespace (where

--- a/example/tests/test-implementations/test-37-cross-namespace-serviceaccount-references.sh
+++ b/example/tests/test-implementations/test-37-cross-namespace-serviceaccount-references.sh
@@ -31,8 +31,12 @@ EOF
 
 sleep 15
 
-# Get managed namespaces (owned by THIS test's CR - issue #35)
-MANAGED_NAMESPACES=$(list_owned_namespaces "test-sa-cross-ns" | tr '\n' ' ')
+# Enumerate namespaces via the ServiceAccounts this CR actually created:
+# under the ownership gate (issue #43) shared namespaces stay claimed by the
+# baseline CR, so namespace-ownership listing would be empty and the test
+# vacuous. SAs carry app.kubernetes.io/name=<cr-name>.
+MANAGED_NAMESPACES=$(kubectl get sa -A -l "app.kubernetes.io/name=test-sa-cross-ns" \
+    -o custom-columns=NS:.metadata.namespace --no-headers 2>/dev/null | sort -u | tr '\n' ' ')
 
 if [ -n "$MANAGED_NAMESPACES" ]; then
     SA_COUNT=0

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -48,9 +48,10 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 )
 
-// parseWatchNamespaces parses a comma-separated list of namespaces from the
-// WATCH_NAMESPACE environment variable. Empty segments and surrounding
-// whitespace are ignored; an empty value yields an empty slice (cluster-wide).
+// parseWatchNamespaces parses a comma-separated list of namespaces (used for
+// both the WATCH_NAMESPACE and RECONCILE_NAMESPACES environment variables).
+// Empty segments and surrounding whitespace are ignored; an empty value yields
+// an empty slice (= no restriction).
 func parseWatchNamespaces(value string) []string {
 	var namespaces []string
 	for _, ns := range strings.Split(value, ",") {
@@ -175,7 +176,8 @@ func main() {
 	// When unset or empty, the operator keeps the current cluster-wide behavior.
 	// This enables running multiple isolated operator instances (e.g. parallel e2e tests),
 	// each watching only its own namespaces.
-	if watchNamespaces := parseWatchNamespaces(os.Getenv("WATCH_NAMESPACE")); len(watchNamespaces) > 0 {
+	watchNamespaces := parseWatchNamespaces(os.Getenv("WATCH_NAMESPACE"))
+	if len(watchNamespaces) > 0 {
 		defaultNamespaces := make(map[string]cache.Config, len(watchNamespaces))
 		for _, ns := range watchNamespaces {
 			defaultNamespaces[ns] = cache.Config{}
@@ -195,9 +197,37 @@ func main() {
 	// MANAGED_BY_VALUE optionally overrides the value of the managed-by label/annotation
 	// that this instance stamps on resources it creates and selects in cluster-wide lists.
 	// When unset, the default value is used (single-instance deployments are unaffected).
+	// NOTE: only safe in multi-instance deployments when combined with
+	// RECONCILE_NAMESPACES (issue #43) - without CR scoping every instance still
+	// reconciles every PermissionBinder and re-stamps foreign resources.
 	if managedByValue := strings.TrimSpace(os.Getenv("MANAGED_BY_VALUE")); managedByValue != "" {
 		controller.ManagedByValue = managedByValue
 		setupLog.Info("Using custom managed-by value", "managedByValue", managedByValue)
+	}
+
+	// RECONCILE_NAMESPACES (comma-separated) restricts which PermissionBinder CRs
+	// this instance reconciles, by CR namespace (issue #43). Unlike WATCH_NAMESPACE
+	// it does NOT scope the cache, so dynamically created target namespaces stay
+	// visible. Unset or empty = reconcile CRs from all namespaces (default).
+	reconcileNamespaces := parseWatchNamespaces(os.Getenv("RECONCILE_NAMESPACES"))
+	if len(reconcileNamespaces) > 0 {
+		setupLog.Info("Reconciling PermissionBinders only from namespaces", "namespaces", reconcileNamespaces)
+	}
+
+	// When both are set, RECONCILE_NAMESPACES must be a subset of
+	// WATCH_NAMESPACE: a CR namespace outside the cache scope has no informer,
+	// so its CRs are silently never reconciled (issue #43).
+	if len(watchNamespaces) > 0 {
+		watched := make(map[string]struct{}, len(watchNamespaces))
+		for _, ns := range watchNamespaces {
+			watched[ns] = struct{}{}
+		}
+		for _, ns := range reconcileNamespaces {
+			if _, ok := watched[ns]; !ok {
+				setupLog.Info("WARNING: RECONCILE_NAMESPACES entry is outside WATCH_NAMESPACE - PermissionBinders in this namespace will never be reconciled",
+					"namespace", ns)
+			}
+		}
 	}
 
 	// Check if debug mode is enabled via environment variable
@@ -207,9 +237,10 @@ func main() {
 	}
 
 	if err = (&controller.PermissionBinderReconciler{
-		Client:    mgr.GetClient(),
-		Scheme:    mgr.GetScheme(),
-		DebugMode: debugMode,
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		DebugMode:           debugMode,
+		ReconcileNamespaces: reconcileNamespaces,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PermissionBinder")
 		os.Exit(1)

--- a/operator/cmd/main_test.go
+++ b/operator/cmd/main_test.go
@@ -62,6 +62,13 @@ func TestParseWatchNamespaces(t *testing.T) {
 			value:    "e2e-test-a,",
 			expected: []string{"e2e-test-a"},
 		},
+		{
+			// The same parser backs RECONCILE_NAMESPACES (issue #43); the
+			// semantics (trim, drop empties, empty = no restriction) are shared.
+			name:     "RECONCILE_NAMESPACES-style CR allowlist",
+			value:    "pbo-e2e-1, pbo-e2e-2",
+			expected: []string{"pbo-e2e-1", "pbo-e2e-2"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -68,15 +68,34 @@ spec:
         image: controller:latest
         name: manager
         # env:
-          # WATCH_NAMESPACE (comma-separated) scopes the operator cache to the
-          # listed namespaces. When unset, the operator watches all namespaces
-          # (default). Set it to run multiple isolated instances (e.g. parallel
-          # e2e tests), each watching only its own namespaces.
+          # RECONCILE_NAMESPACES (comma-separated) restricts which
+          # PermissionBinder CRs this instance reconciles, by CR namespace.
+          # The cache stays cluster-wide, so dynamically created target
+          # namespaces remain visible - the recommended scoping knob for
+          # multi-instance deployments. Unset = reconcile all CRs (default).
+          # When combined with WATCH_NAMESPACE, this list must be a SUBSET of
+          # it (entries outside the cache are silently never reconciled).
+          # Narrowing the list leaves CRs with the operator finalizer in
+          # uncovered namespaces undeletable (stuck Terminating).
+          # - name: RECONCILE_NAMESPACES
+          #   value: "my-operator-ns"
+          # WATCH_NAMESPACE (comma-separated) scopes the ENTIRE operator cache.
+          # The list MUST include the CR's namespace, spec.configMapNamespace
+          # and EVERY target namespace derived from the whitelist - a cached
+          # Get/List in any unlisted namespace hard-fails with "unknown
+          # namespace for the cache" (partial reconciliation: namespace
+          # created, RoleBindings missing), and onboarding a new namespace
+          # requires an operator restart with an updated list. Unsuitable for
+          # dynamic namespace onboarding; prefer RECONCILE_NAMESPACES.
+          # When unset, the operator watches all namespaces (default).
           # - name: WATCH_NAMESPACE
-          #   value: "my-operator-ns,my-test-ns"
+          #   value: "my-operator-ns,my-config-ns,my-target-ns-1,my-target-ns-2"
           # MANAGED_BY_VALUE overrides the managed-by label/annotation value this
           # instance stamps on resources it creates and selects in cluster-wide
           # lists. Give each instance a unique value in multi-instance setups.
+          # NOT isolation by itself - only safe combined with
+          # RECONCILE_NAMESPACES (or fully disjoint WATCH_NAMESPACE sets),
+          # otherwise instances re-stamp each other's resources.
           # - name: MANAGED_BY_VALUE
           #   value: "permission-binder-operator-e2e-a"
         securityContext:

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect

--- a/operator/internal/controller/controller_setup.go
+++ b/operator/internal/controller/controller_setup.go
@@ -57,7 +57,7 @@ func (r *PermissionBinderReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&permissionv1.PermissionBinder{}, builder.WithPredicates(permissionBinderPredicate())).
+		For(&permissionv1.PermissionBinder{}, builder.WithPredicates(r.permissionBinderPredicate())).
 		Watches(
 			&corev1.ConfigMap{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
@@ -91,8 +91,14 @@ func (r *PermissionBinderReconciler) isConfigMapReferenced(c client.Client, obj 
 		return true
 	}
 
-	// If any PermissionBinders reference this ConfigMap, return true
-	return len(permissionBinders.Items) > 0
+	// Only count PermissionBinders this instance reconciles (RECONCILE_NAMESPACES,
+	// issue #43) - a ConfigMap referenced solely by foreign CRs is not ours to react to
+	for _, pb := range permissionBinders.Items {
+		if r.reconcilesNamespace(pb.Namespace) {
+			return true
+		}
+	}
+	return false
 }
 
 // mapConfigMapToPermissionBinder maps ConfigMap changes to PermissionBinder reconciliation
@@ -113,6 +119,11 @@ func (r *PermissionBinderReconciler) mapConfigMapToPermissionBinder(ctx context.
 
 	var requests []reconcile.Request
 	for _, pb := range permissionBinders.Items {
+		// Skip CRs outside RECONCILE_NAMESPACES (issue #43): this handler
+		// enqueues directly into the workqueue, bypassing the For() predicate
+		if !r.reconcilesNamespace(pb.Namespace) {
+			continue
+		}
 		// Check if this ConfigMap is referenced by this PermissionBinder
 		if pb.Spec.ConfigMapName == obj.Name && pb.Spec.ConfigMapNamespace == obj.Namespace {
 			if r.DebugMode {

--- a/operator/internal/controller/metrics.go
+++ b/operator/internal/controller/metrics.go
@@ -59,6 +59,18 @@ var (
 		},
 	)
 
+	// Counter for refused ownership takeovers (issue #43): a resource carrying
+	// a live claim by ANOTHER PermissionBinder was skipped by the write path
+	// instead of being stolen. resource_type: namespace | rolebinding |
+	// serviceaccount_rolebinding.
+	ownershipConflictsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "permission_binder_ownership_conflicts_total",
+			Help: "Total number of refused resource takeovers due to a live ownership claim by another PermissionBinder",
+		},
+		[]string{"resource_type"},
+	)
+
 	// Gauge for managed RoleBindings
 	managedRoleBindingsTotal = prometheus.NewGauge(
 		prometheus.GaugeOpts{
@@ -126,6 +138,7 @@ func init() {
 		missingClusterRoleTotal,
 		orphanedResourcesTotal,
 		adoptionEventsTotal,
+		ownershipConflictsTotal,
 		ldapGroupOperationsTotal,
 		ldapConnectionsTotal,
 		managedRoleBindingsTotal,
@@ -162,7 +175,7 @@ func (r *PermissionBinderReconciler) updateMetrics(ctx context.Context, permissi
 	orphanedNS := 0
 
 	for _, rb := range roleBindings {
-		if rb.Annotations != nil && rb.Annotations["permission-binder.io/orphaned-at"] != "" {
+		if rb.Annotations != nil && rb.Annotations[AnnotationOrphanedAt] != "" {
 			orphanedRB++
 		}
 	}
@@ -176,7 +189,7 @@ func (r *PermissionBinderReconciler) updateMetrics(ctx context.Context, permissi
 		selector = selector.Add(*req)
 		if err := r.List(ctx, &nsList, &client.ListOptions{LabelSelector: selector}); err == nil {
 			for _, ns := range nsList.Items {
-				if ns.Annotations != nil && ns.Annotations["permission-binder.io/orphaned-at"] != "" {
+				if ns.Annotations != nil && ns.Annotations[AnnotationOrphanedAt] != "" {
 					orphanedNS++
 				}
 			}

--- a/operator/internal/controller/networkpolicy/network_policy_business_logic_test.go
+++ b/operator/internal/controller/networkpolicy/network_policy_business_logic_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -141,11 +142,66 @@ func TestCheckMultiplePermissionBinders(t *testing.T) {
 			}
 			r := setupFakeClient(objs...)
 
-			err := CheckMultiplePermissionBinders(ctx, r)
+			err := CheckMultiplePermissionBinders(ctx, r, nil)
 			require.NoError(t, err)
 
 			// Note: We can't easily test metrics increment without exposing them,
 			// but the function should complete without error
+		})
+	}
+}
+
+// TestCheckMultiplePermissionBindersNamespaceScoping verifies that the
+// allowedNamespaces filter (RECONCILE_NAMESPACES, issue #43) excludes foreign
+// instances' CRs from the multiple-CR count: two NetworkPolicy-enabled binders
+// in different namespaces do not trip the warning when the instance is scoped
+// to one of them.
+func TestCheckMultiplePermissionBindersNamespaceScoping(t *testing.T) {
+	binders := []*permissionv1.PermissionBinder{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "binder-a", Namespace: "instance-a"},
+			Spec: permissionv1.PermissionBinderSpec{
+				NetworkPolicy: &permissionv1.NetworkPolicySpec{Enabled: true},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "binder-b", Namespace: "instance-b"},
+			Spec: permissionv1.PermissionBinderSpec{
+				NetworkPolicy: &permissionv1.NetworkPolicySpec{Enabled: true},
+			},
+		},
+	}
+
+	tests := []struct {
+		name              string
+		allowedNamespaces []string
+		expectWarning     bool
+	}{
+		{name: "nil allowlist considers all namespaces", allowedNamespaces: nil, expectWarning: true},
+		{name: "scoped to instance-a ignores instance-b", allowedNamespaces: []string{"instance-a"}, expectWarning: false},
+		{name: "scoped to both sees both", allowedNamespaces: []string{"instance-a", "instance-b"}, expectWarning: true},
+		{name: "scoped to unknown namespace sees none", allowedNamespaces: []string{"instance-c"}, expectWarning: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			objs := make([]client.Object, len(binders))
+			for i, binder := range binders {
+				objs[i] = binder
+			}
+			r := setupFakeClient(objs...)
+
+			before := testutil.ToFloat64(NetworkPolicyMultipleCRsWarningTotal)
+			err := CheckMultiplePermissionBinders(ctx, r, tt.allowedNamespaces)
+			require.NoError(t, err)
+			delta := testutil.ToFloat64(NetworkPolicyMultipleCRsWarningTotal) - before
+
+			if tt.expectWarning {
+				require.Equal(t, float64(1), delta, "expected the multiple-CRs warning metric to increment")
+			} else {
+				require.Equal(t, float64(0), delta, "expected no multiple-CRs warning for a scoped instance")
+			}
 		})
 	}
 }

--- a/operator/internal/controller/networkpolicy/reconciliation_validation.go
+++ b/operator/internal/controller/networkpolicy/reconciliation_validation.go
@@ -36,19 +36,24 @@ import (
 // Parameters:
 //   - ctx: Context for cancellation and timeout
 //   - r: ReconcilerInterface for Kubernetes API access
+//   - allowedNamespaces: CR namespaces this instance reconciles
+//     (RECONCILE_NAMESPACES, issue #43); nil or empty = consider all
+//     namespaces. Keeps a scoped instance from warning about foreign
+//     instances' NetworkPolicy-enabled CRs.
 //
 // Returns:
 //   - error: Returns an error if listing PermissionBinders fails, nil otherwise
 //
 // Example:
 //
-//	err := CheckMultiplePermissionBinders(ctx, reconciler)
+//	err := CheckMultiplePermissionBinders(ctx, reconciler, nil)
 //	if err != nil {
 //	    return fmt.Errorf("validation failed: %w", err)
 //	}
 func CheckMultiplePermissionBinders(
 	ctx context.Context,
 	r ReconcilerInterface,
+	allowedNamespaces []string,
 ) error {
 	logger := log.FromContext(ctx)
 
@@ -57,8 +62,23 @@ func CheckMultiplePermissionBinders(
 		return fmt.Errorf("failed to list PermissionBinders: %w", err)
 	}
 
+	namespaceAllowed := func(namespace string) bool {
+		if len(allowedNamespaces) == 0 {
+			return true
+		}
+		for _, ns := range allowedNamespaces {
+			if ns == namespace {
+				return true
+			}
+		}
+		return false
+	}
+
 	enabledCount := 0
 	for _, binder := range binders.Items {
+		if !namespaceAllowed(binder.Namespace) {
+			continue
+		}
 		if binder.Spec.NetworkPolicy != nil && binder.Spec.NetworkPolicy.Enabled {
 			enabledCount++
 		}

--- a/operator/internal/controller/ownership_scoping_test.go
+++ b/operator/internal/controller/ownership_scoping_test.go
@@ -102,17 +102,19 @@ func TestIsOwnedByPermissionBinder(t *testing.T) {
 			expected:    false,
 			description: "Legacy resources of a different CR must not match",
 		},
-		// Namespace-less CR (e.g. plain envtest client without namespace defaulting)
+		// Namespace-less CR: strict matching (issue #43) - the CRD is
+		// namespace-scoped, so an empty CR namespace never occurs in a real
+		// cluster; the old name-only fallback was a silent isolation-loss trap.
 		{
-			name: "namespace-less CR matches namespaced resource by name (backward compatibility)",
+			name: "namespace-less CR does NOT match a namespace-stamped resource",
 			annotations: map[string]string{
 				AnnotationPermissionBinder:          "example",
 				AnnotationPermissionBinderNamespace: "instance-a",
 			},
 			pbNamespace: "",
 			pbName:      "example",
-			expected:    true,
-			description: "CRs without namespace (existing envtest fixtures) keep name-only matching",
+			expected:    false,
+			description: "The pb.Namespace==\"\" name-only fallback was removed (issue #43)",
 		},
 		{
 			name: "namespace-less CR matches legacy resource by name",
@@ -197,5 +199,123 @@ func TestManagedByValueOverride(t *testing.T) {
 	}
 	if AnnotationPermissionBinderNamespace != "permission-binder.io/permission-binder-namespace" {
 		t.Errorf("Unexpected ownership namespace annotation key: %q", AnnotationPermissionBinderNamespace)
+	}
+}
+
+// TestCanTakeOwnership covers the write-path ownership gate (issue #43):
+// unclaimed, own, legacy and orphaned resources are manageable; a live claim
+// by another PermissionBinder is refused. The decision is annotation-based
+// only - spec drift never factors in (manual-modification protection).
+func TestCanTakeOwnership(t *testing.T) {
+	const owner, ownerNs = "example", "instance-a"
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			name:        "nil annotations (unclaimed) - allowed",
+			annotations: nil,
+			expected:    true,
+		},
+		{
+			name:        "no ownership annotation (unclaimed pre-existing resource) - allowed",
+			annotations: map[string]string{AnnotationManagedBy: ManagedByValue},
+			expected:    true,
+		},
+		{
+			name: "owned by this CR (name + namespace) - allowed",
+			annotations: map[string]string{
+				AnnotationPermissionBinder:          owner,
+				AnnotationPermissionBinderNamespace: ownerNs,
+			},
+			expected: true,
+		},
+		{
+			name: "legacy name-only claim by same name - allowed (retroactive namespace stamp)",
+			annotations: map[string]string{
+				AnnotationPermissionBinder: owner,
+			},
+			expected: true,
+		},
+		{
+			name: "live claim by different CR name - refused",
+			annotations: map[string]string{
+				AnnotationPermissionBinder:          "other",
+				AnnotationPermissionBinderNamespace: ownerNs,
+			},
+			expected: false,
+		},
+		{
+			name: "live claim by same CR name in another namespace - refused (steal-then-delete prevention)",
+			annotations: map[string]string{
+				AnnotationPermissionBinder:          owner,
+				AnnotationPermissionBinderNamespace: "instance-b",
+			},
+			expected: false,
+		},
+		{
+			name: "foreign claim WITH orphan marker - allowed (explicit adoption / CR namespace migration)",
+			annotations: map[string]string{
+				AnnotationPermissionBinder:          owner,
+				AnnotationPermissionBinderNamespace: "instance-b",
+				AnnotationOrphanedAt:                "2026-08-21T00:00:00Z",
+				AnnotationOrphanedBy:                OrphanedByPermissionBinderDeletion,
+			},
+			expected: true,
+		},
+		{
+			name: "foreign NAME with orphan marker - allowed (orphans are adoptable by anyone)",
+			annotations: map[string]string{
+				AnnotationPermissionBinder: "other",
+				AnnotationOrphanedAt:       "2026-08-21T00:00:00Z",
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := canTakeOwnership(tt.annotations, owner, ownerNs); got != tt.expected {
+				t.Errorf("canTakeOwnership() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestIsOwnedByStrictNamespace pins the strictness introduced by issue #43:
+// an empty owner namespace no longer falls back to name-only matching against
+// namespace-stamped resources.
+func TestIsOwnedByStrictNamespace(t *testing.T) {
+	stamped := map[string]string{
+		AnnotationPermissionBinder:          "example",
+		AnnotationPermissionBinderNamespace: "instance-a",
+	}
+	if isOwnedBy(stamped, "example", "") {
+		t.Error("empty owner namespace must NOT match a namespace-stamped resource")
+	}
+	legacy := map[string]string{AnnotationPermissionBinder: "example"}
+	if !isOwnedBy(legacy, "example", "") {
+		t.Error("legacy name-only resources must still match by name")
+	}
+	if !isOwnedBy(legacy, "example", "instance-a") {
+		t.Error("legacy name-only resources must match a namespaced owner by name")
+	}
+}
+
+// TestIsOwnedByEmptyNamespaceValue pins the degenerate-stamp handling: a
+// present-but-empty namespace annotation is treated as legacy (name match)
+// instead of permanently wedging the resource against every real CR.
+func TestIsOwnedByEmptyNamespaceValue(t *testing.T) {
+	degenerate := map[string]string{
+		AnnotationPermissionBinder:          "example",
+		AnnotationPermissionBinderNamespace: "",
+	}
+	if !isOwnedBy(degenerate, "example", "instance-a") {
+		t.Error("empty-value namespace annotation must fall back to name matching")
+	}
+	if isOwnedBy(degenerate, "other", "instance-a") {
+		t.Error("empty-value namespace annotation must still require a name match")
 	}
 }

--- a/operator/internal/controller/predicates.go
+++ b/operator/internal/controller/predicates.go
@@ -59,13 +59,19 @@ func (r *PermissionBinderReconciler) configMapPredicate(mgr interface {
 }
 
 // permissionBinderPredicate filters PermissionBinder events to ignore status-only updates
-// This prevents reconciliation loops caused by status updates
-func permissionBinderPredicate() predicate.Predicate {
+// This prevents reconciliation loops caused by status updates.
+// It also drops events for CRs outside RECONCILE_NAMESPACES (issue #43) so a
+// scoped instance never reconciles - and never re-stamps - foreign CRs.
+func (r *PermissionBinderReconciler) permissionBinderPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			return true
+			return r.reconcilesNamespace(e.Object.GetNamespace())
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
+			if !r.reconcilesNamespace(e.ObjectNew.GetNamespace()) {
+				return false
+			}
+
 			// Only reconcile if spec or metadata changed, not status-only changes
 			oldObj := e.ObjectOld.(*permissionv1.PermissionBinder)
 			newObj := e.ObjectNew.(*permissionv1.PermissionBinder)
@@ -89,10 +95,10 @@ func permissionBinderPredicate() predicate.Predicate {
 			return false
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return true
+			return r.reconcilesNamespace(e.Object.GetNamespace())
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
-			return true
+			return r.reconcilesNamespace(e.Object.GetNamespace())
 		},
 	}
 }

--- a/operator/internal/controller/reconciliation_cleanup.go
+++ b/operator/internal/controller/reconciliation_cleanup.go
@@ -44,26 +44,61 @@ import (
 //   - Legacy resources only carry AnnotationPermissionBinder (name-only, no
 //     namespace). They are still adopted by name match alone, preserving the
 //     pre-existing behavior (backward compatibility).
-//   - When the reconciled CR has no namespace (e.g. CRs created via plain
-//     envtest clients), matching falls back to name-only as well.
 func isOwnedByPermissionBinder(annotations map[string]string, permissionBinder *permissionv1.PermissionBinder) bool {
+	return isOwnedBy(annotations, permissionBinder.Name, permissionBinder.Namespace)
+}
+
+// isOwnedBy is the string-based form of isOwnedByPermissionBinder, usable from
+// helpers that carry the owner identity as plain strings (ServiceAccount flow).
+// The CRD is namespace-scoped, so ownerNamespace is never empty in a real
+// cluster; an empty ownerNamespace matches only resources without the
+// namespace annotation (legacy) - there is deliberately NO name-only fallback
+// for namespaced owners, to avoid silent cross-instance ownership loss.
+func isOwnedBy(annotations map[string]string, ownerName, ownerNamespace string) bool {
 	if annotations == nil {
 		return false
 	}
-	if annotations[AnnotationPermissionBinder] != permissionBinder.Name {
+	if annotations[AnnotationPermissionBinder] != ownerName {
 		return false
 	}
-	ownerNamespace, hasNamespaceAnnotation := annotations[AnnotationPermissionBinderNamespace]
-	if !hasNamespaceAnnotation {
-		// Legacy resource annotated before ownership became namespace-aware.
+	stampedNamespace := annotations[AnnotationPermissionBinderNamespace]
+	if stampedNamespace == "" {
+		// Legacy resource annotated before ownership became namespace-aware
+		// (or a degenerate empty-value stamp) - match by name alone so such
+		// resources stay manageable instead of being permanently wedged.
 		return true
 	}
-	if permissionBinder.Namespace == "" {
-		// The reconciled CR carries no namespace (e.g. plain envtest clients).
-		// Fall back to name-only matching so existing behavior is preserved.
-		return true
+	return stampedNamespace == ownerNamespace
+}
+
+// canTakeOwnership decides whether the adopt/update (write) path may manage a
+// resource carrying the given annotations, closing the steal-then-delete gap
+// (issue #43): deletion paths already respect ownership, but create/update
+// paths used to adopt unconditionally.
+//
+// The decision is based ONLY on the ownership/orphan annotations - never on
+// spec drift - so manual modifications of an OWNED resource are still
+// reverted (e2e test 15).
+//
+// Allowed:
+//   - unclaimed: no AnnotationPermissionBinder at all (pre-existing user
+//     resources; preserves the long-standing adoption of plain namespaces),
+//   - owned: isOwnedBy() matches, including legacy name-only resources
+//     (which then get the namespace annotation stamped retroactively),
+//   - orphaned: AnnotationOrphanedAt is set by SAFE-MODE cleanup - explicit
+//     adoption, and the documented migration path for moving a CR between
+//     namespaces (delete old CR -> orphan -> recreate -> re-adopt).
+//
+// Refused: a live claim by ANOTHER PermissionBinder (different name or
+// namespace) with no orphan marker.
+func canTakeOwnership(annotations map[string]string, ownerName, ownerNamespace string) bool {
+	if annotations == nil || annotations[AnnotationPermissionBinder] == "" {
+		return true // unclaimed
 	}
-	return ownerNamespace == permissionBinder.Namespace
+	if isOwnedBy(annotations, ownerName, ownerNamespace) {
+		return true // already ours (or legacy name-only match)
+	}
+	return annotations[AnnotationOrphanedAt] != "" // explicit orphan - adoptable
 }
 
 // cleanupManagedResources cleans up all resources managed by this PermissionBinder
@@ -84,8 +119,8 @@ func (r *PermissionBinderReconciler) cleanupManagedResources(ctx context.Context
 			if roleBinding.Annotations == nil {
 				roleBinding.Annotations = make(map[string]string)
 			}
-			roleBinding.Annotations["permission-binder.io/orphaned-at"] = time.Now().Format(time.RFC3339)
-			roleBinding.Annotations["permission-binder.io/orphaned-by"] = "permission-binder-deletion"
+			roleBinding.Annotations[AnnotationOrphanedAt] = time.Now().Format(time.RFC3339)
+			roleBinding.Annotations[AnnotationOrphanedBy] = OrphanedByPermissionBinderDeletion
 
 			if err := r.Update(ctx, &roleBinding); err != nil {
 				logger.Error(err, "Failed to annotate RoleBinding as orphaned", "namespace", roleBinding.Namespace, "name", roleBinding.Name)
@@ -111,8 +146,8 @@ func (r *PermissionBinderReconciler) cleanupManagedResources(ctx context.Context
 			if ns.Annotations == nil {
 				ns.Annotations = make(map[string]string)
 			}
-			ns.Annotations["permission-binder.io/orphaned-at"] = time.Now().Format(time.RFC3339)
-			ns.Annotations["permission-binder.io/orphaned-by"] = "permission-binder-deletion"
+			ns.Annotations[AnnotationOrphanedAt] = time.Now().Format(time.RFC3339)
+			ns.Annotations[AnnotationOrphanedBy] = OrphanedByPermissionBinderDeletion
 
 			if err := r.Update(ctx, &ns); err != nil {
 				logger.Error(err, "Failed to annotate namespace as orphaned", "namespace", namespace)

--- a/operator/internal/controller/reconciliation_configmap.go
+++ b/operator/internal/controller/reconciliation_configmap.go
@@ -106,8 +106,16 @@ func (r *PermissionBinderReconciler) processConfigMap(ctx context.Context, permi
 		// Create RoleBinding (use the CN value as the group subject name)
 		// OpenShift LDAP syncer creates groups with CN value as name, not full DN
 		roleBindingName := fmt.Sprintf("%s-%s", namespace, role)
-		if err := r.createRoleBinding(ctx, namespace, roleBindingName, role, cnValue, permissionBinder.Spec.RoleMapping[role], permissionBinder); err != nil {
+		managed, err := r.createRoleBinding(ctx, namespace, roleBindingName, role, cnValue, permissionBinder.Spec.RoleMapping[role], permissionBinder)
+		if err != nil {
 			logger.Error(err, "Failed to create RoleBinding", "namespace", namespace, "role", role)
+			continue
+		}
+		if !managed {
+			// Ownership gate refused the takeover (issue #43): the RoleBinding
+			// belongs to another PermissionBinder - do not report it as
+			// successfully processed by this CR.
+			configMapEntriesProcessed.WithLabelValues("ownership_conflict").Inc()
 			continue
 		}
 

--- a/operator/internal/controller/reconciliation_main.go
+++ b/operator/internal/controller/reconciliation_main.go
@@ -48,6 +48,14 @@ const (
 	// name collision between instances no longer causes cross-instance deletion.
 	AnnotationPermissionBinderNamespace = "permission-binder.io/permission-binder-namespace"
 	AnnotationRole                      = "permission-binder.io/role"
+	// Orphan markers set by SAFE-MODE cleanup when a PermissionBinder is
+	// deleted; their presence makes a resource adoptable by another CR.
+	AnnotationOrphanedAt = "permission-binder.io/orphaned-at"
+	AnnotationOrphanedBy = "permission-binder.io/orphaned-by"
+
+	// OrphanedByPermissionBinderDeletion is the AnnotationOrphanedBy value
+	// stamped by SAFE-MODE cleanup.
+	OrphanedByPermissionBinderDeletion = "permission-binder-deletion"
 
 	// Label keys
 	LabelManagedBy = "permission-binder.io/managed-by"
@@ -72,6 +80,27 @@ type PermissionBinderReconciler struct {
 	client.Client
 	Scheme    *runtime.Scheme
 	DebugMode bool
+	// ReconcileNamespaces optionally restricts which PermissionBinder CRs this
+	// instance reconciles, by CR namespace (RECONCILE_NAMESPACES env,
+	// comma-separated). Empty = reconcile CRs from all namespaces (default).
+	// Unlike WATCH_NAMESPACE it does NOT scope the cache, so dynamically
+	// created target namespaces stay visible - this is the knob that makes
+	// MANAGED_BY_VALUE safe in multi-instance deployments.
+	ReconcileNamespaces []string
+}
+
+// reconcilesNamespace reports whether this instance reconciles PermissionBinder
+// CRs living in the given namespace.
+func (r *PermissionBinderReconciler) reconcilesNamespace(namespace string) bool {
+	if len(r.ReconcileNamespaces) == 0 {
+		return true
+	}
+	for _, ns := range r.ReconcileNamespaces {
+		if ns == namespace {
+			return true
+		}
+	}
+	return false
 }
 
 // Status returns the StatusWriter for updating subresource status
@@ -95,6 +124,12 @@ func (r *PermissionBinderReconciler) Status() client.StatusWriter {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.19.0/pkg/reconcile
 func (r *PermissionBinderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
+
+	// RECONCILE_NAMESPACES backstop (issue #43): covers every enqueue path,
+	// including RequeueAfter items and future handlers, not just watch events
+	if !r.reconcilesNamespace(req.Namespace) {
+		return ctrl.Result{}, nil
+	}
 
 	// Log reconciliation trigger in debug mode
 	if r.DebugMode {
@@ -268,7 +303,7 @@ func (r *PermissionBinderReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// Process NetworkPolicies if enabled
 	if permissionBinder.Spec.NetworkPolicy != nil && permissionBinder.Spec.NetworkPolicy.Enabled {
 		// Check for multiple PermissionBinder CRs with NetworkPolicy enabled
-		if err := networkpolicy.CheckMultiplePermissionBinders(ctx, r); err != nil {
+		if err := networkpolicy.CheckMultiplePermissionBinders(ctx, r, r.ReconcileNamespaces); err != nil {
 			logger.Error(err, "Failed to check multiple PermissionBinders (non-fatal)")
 			// Continue - not blocking
 		}

--- a/operator/internal/controller/reconciliation_rolebindings.go
+++ b/operator/internal/controller/reconciliation_rolebindings.go
@@ -62,6 +62,20 @@ func (r *PermissionBinderReconciler) ensureNamespace(ctx context.Context, namesp
 			return fmt.Errorf("failed to get namespace %s: %w", namespace, err)
 		}
 	} else {
+		// OWNERSHIP GATE (issue #43): never take over a namespace with a live
+		// claim by another PermissionBinder. Unclaimed, own, legacy name-only
+		// and explicitly orphaned namespaces remain adoptable.
+		if !canTakeOwnership(ns.Annotations, permissionBinder.Name, permissionBinder.Namespace) {
+			ownershipConflictsTotal.WithLabelValues("namespace").Inc()
+			logger.Info("Refusing to take ownership of namespace claimed by another PermissionBinder",
+				"namespace", namespace,
+				"claimedBy", ns.Annotations[AnnotationPermissionBinder],
+				"claimedByNamespace", ns.Annotations[AnnotationPermissionBinderNamespace],
+				"reconciledBy", permissionBinder.Name,
+				"reconciledByNamespace", permissionBinder.Namespace)
+			return nil
+		}
+
 		// Update existing namespace with annotations if not present
 		needsUpdate := false
 		if ns.Annotations == nil {
@@ -73,9 +87,9 @@ func (r *PermissionBinderReconciler) ensureNamespace(ctx context.Context, namesp
 
 		// ADOPTION LOGIC: Remove orphaned annotations if present
 		// This allows automatic recovery when PermissionBinder is recreated
-		if ns.Annotations["permission-binder.io/orphaned-at"] != "" {
-			delete(ns.Annotations, "permission-binder.io/orphaned-at")
-			delete(ns.Annotations, "permission-binder.io/orphaned-by")
+		if ns.Annotations[AnnotationOrphanedAt] != "" {
+			delete(ns.Annotations, AnnotationOrphanedAt)
+			delete(ns.Annotations, AnnotationOrphanedBy)
 			needsUpdate = true
 
 			// Increment adoption metrics (automatic recovery)
@@ -145,8 +159,12 @@ func (r *PermissionBinderReconciler) validateClusterRoleExists(ctx context.Conte
 	return true
 }
 
-// createRoleBinding creates a RoleBinding in the specified namespace
-func (r *PermissionBinderReconciler) createRoleBinding(ctx context.Context, namespace, name, role, group, clusterRole string, permissionBinder *permissionv1.PermissionBinder) error {
+// createRoleBinding ensures the desired RoleBinding exists and is owned by
+// the given PermissionBinder. It returns managed=false (with a nil error) when
+// the RoleBinding is claimed by another PermissionBinder and the ownership
+// gate refused the takeover - the caller must not report such an entry as
+// successfully processed.
+func (r *PermissionBinderReconciler) createRoleBinding(ctx context.Context, namespace, name, role, group, clusterRole string, permissionBinder *permissionv1.PermissionBinder) (managed bool, err error) {
 	logger := log.FromContext(ctx)
 	now := time.Now().Format(time.RFC3339)
 
@@ -193,20 +211,36 @@ func (r *PermissionBinderReconciler) createRoleBinding(ctx context.Context, name
 
 	// Check if RoleBinding already exists
 	var existing rbacv1.RoleBinding
-	err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &existing)
+	err = r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &existing)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Create new RoleBinding
 			if err := r.Create(ctx, roleBinding); err != nil {
-				return fmt.Errorf("failed to create RoleBinding %s/%s: %w", namespace, name, err)
+				return false, fmt.Errorf("failed to create RoleBinding %s/%s: %w", namespace, name, err)
 			}
 		} else {
-			return fmt.Errorf("failed to get RoleBinding %s/%s: %w", namespace, name, err)
+			return false, fmt.Errorf("failed to get RoleBinding %s/%s: %w", namespace, name, err)
 		}
 	} else {
+		// OWNERSHIP GATE (issue #43): never overwrite a RoleBinding with a live
+		// claim by another PermissionBinder (steal-then-delete prevention).
+		// Gate is annotation-based ONLY - spec drift on an OWNED RoleBinding is
+		// still reverted below (manual-modification protection, e2e test 15).
+		if !canTakeOwnership(existing.Annotations, permissionBinder.Name, permissionBinder.Namespace) {
+			ownershipConflictsTotal.WithLabelValues("rolebinding").Inc()
+			logger.Info("Refusing to take ownership of RoleBinding claimed by another PermissionBinder",
+				"namespace", namespace,
+				"roleBinding", name,
+				"claimedBy", existing.Annotations[AnnotationPermissionBinder],
+				"claimedByNamespace", existing.Annotations[AnnotationPermissionBinderNamespace],
+				"reconciledBy", permissionBinder.Name,
+				"reconciledByNamespace", permissionBinder.Namespace)
+			return false, nil
+		}
+
 		// Check if RoleBinding needs update - avoid unnecessary updates that change ResourceVersion
 		needsUpdate := false
-		hasOrphanedAnnotation := existing.Annotations["permission-binder.io/orphaned-at"] != ""
+		hasOrphanedAnnotation := existing.Annotations[AnnotationOrphanedAt] != ""
 
 		// Check if RoleRef changed
 		if existing.RoleRef != roleBinding.RoleRef {
@@ -256,7 +290,7 @@ func (r *PermissionBinderReconciler) createRoleBinding(ctx context.Context, name
 		// Only update if something actually changed - this prevents unnecessary ResourceVersion changes
 		if !needsUpdate {
 			// RoleBinding is already up-to-date, no update needed
-			return nil
+			return true, nil
 		}
 
 		// Update existing RoleBinding - OVERRIDE any manual changes
@@ -267,8 +301,8 @@ func (r *PermissionBinderReconciler) createRoleBinding(ctx context.Context, name
 		// ADOPTION LOGIC: Remove orphaned annotations if present
 		// This allows automatic recovery when PermissionBinder is recreated
 		if hasOrphanedAnnotation {
-			delete(existing.Annotations, "permission-binder.io/orphaned-at")
-			delete(existing.Annotations, "permission-binder.io/orphaned-by")
+			delete(existing.Annotations, AnnotationOrphanedAt)
+			delete(existing.Annotations, AnnotationOrphanedBy)
 
 			// Increment adoption metrics (automatic recovery)
 			adoptionEventsTotal.Inc()
@@ -291,9 +325,9 @@ func (r *PermissionBinderReconciler) createRoleBinding(ctx context.Context, name
 		existing.Labels[LabelManagedBy] = ManagedByValue
 
 		if err := r.Update(ctx, &existing); err != nil {
-			return fmt.Errorf("failed to update RoleBinding %s/%s: %w", namespace, name, err)
+			return false, fmt.Errorf("failed to update RoleBinding %s/%s: %w", namespace, name, err)
 		}
 	}
 
-	return nil
+	return true, nil
 }

--- a/operator/internal/controller/scoping_test.go
+++ b/operator/internal/controller/scoping_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	permissionv1 "github.com/permission-binder-operator/operator/api/v1"
+)
+
+// TestReconcilesNamespace covers the RECONCILE_NAMESPACES allowlist check
+// (issue #43): empty = all namespaces, otherwise exact namespace membership.
+func TestReconcilesNamespace(t *testing.T) {
+	tests := []struct {
+		name       string
+		allowlist  []string
+		namespace  string
+		reconciles bool
+	}{
+		{
+			name:       "empty allowlist reconciles every namespace",
+			allowlist:  nil,
+			namespace:  "any-namespace",
+			reconciles: true,
+		},
+		{
+			name:       "namespace in allowlist",
+			allowlist:  []string{"instance-a", "instance-b"},
+			namespace:  "instance-b",
+			reconciles: true,
+		},
+		{
+			name:       "namespace not in allowlist",
+			allowlist:  []string{"instance-a"},
+			namespace:  "instance-b",
+			reconciles: false,
+		},
+		{
+			name:       "no prefix or substring matching",
+			allowlist:  []string{"instance-a"},
+			namespace:  "instance-a-extra",
+			reconciles: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &PermissionBinderReconciler{ReconcileNamespaces: tt.allowlist}
+			if got := r.reconcilesNamespace(tt.namespace); got != tt.reconciles {
+				t.Errorf("reconcilesNamespace(%q) with allowlist %v = %v, want %v",
+					tt.namespace, tt.allowlist, got, tt.reconciles)
+			}
+		})
+	}
+}
+
+// TestPermissionBinderPredicateNamespaceScoping verifies that the
+// PermissionBinder event predicate drops all event types for CRs outside
+// RECONCILE_NAMESPACES while keeping the existing status-only-update
+// suppression for CRs it does reconcile.
+func TestPermissionBinderPredicateNamespaceScoping(t *testing.T) {
+	newPB := func(namespace string, generation int64) *permissionv1.PermissionBinder {
+		return &permissionv1.PermissionBinder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "example",
+				Namespace:  namespace,
+				Generation: generation,
+			},
+		}
+	}
+
+	scoped := (&PermissionBinderReconciler{ReconcileNamespaces: []string{"instance-a"}}).permissionBinderPredicate()
+	unscoped := (&PermissionBinderReconciler{}).permissionBinderPredicate()
+
+	// Create/Delete/Generic: allowed namespace passes, foreign namespace is dropped
+	if !scoped.Create(event.CreateEvent{Object: newPB("instance-a", 1)}) {
+		t.Error("Create event for an allowed namespace should pass")
+	}
+	if scoped.Create(event.CreateEvent{Object: newPB("instance-b", 1)}) {
+		t.Error("Create event for a foreign namespace should be dropped")
+	}
+	if !scoped.Delete(event.DeleteEvent{Object: newPB("instance-a", 1)}) {
+		t.Error("Delete event for an allowed namespace should pass")
+	}
+	if scoped.Delete(event.DeleteEvent{Object: newPB("instance-b", 1)}) {
+		t.Error("Delete event for a foreign namespace should be dropped")
+	}
+	if !scoped.Generic(event.GenericEvent{Object: newPB("instance-a", 1)}) {
+		t.Error("Generic event for an allowed namespace should pass")
+	}
+	if scoped.Generic(event.GenericEvent{Object: newPB("instance-b", 1)}) {
+		t.Error("Generic event for a foreign namespace should be dropped")
+	}
+
+	// Update: spec change in an allowed namespace passes, in a foreign one is dropped
+	specChange := event.UpdateEvent{ObjectOld: newPB("instance-a", 1), ObjectNew: newPB("instance-a", 2)}
+	if !scoped.Update(specChange) {
+		t.Error("spec-change Update in an allowed namespace should pass")
+	}
+	foreignSpecChange := event.UpdateEvent{ObjectOld: newPB("instance-b", 1), ObjectNew: newPB("instance-b", 2)}
+	if scoped.Update(foreignSpecChange) {
+		t.Error("spec-change Update in a foreign namespace should be dropped")
+	}
+
+	// Status-only updates stay suppressed for reconciled CRs (pre-existing behavior)
+	statusOnly := event.UpdateEvent{ObjectOld: newPB("instance-a", 1), ObjectNew: newPB("instance-a", 1)}
+	if scoped.Update(statusOnly) {
+		t.Error("status-only Update should stay suppressed even for an allowed namespace")
+	}
+
+	// Empty allowlist keeps current behavior: everything passes the namespace gate
+	if !unscoped.Create(event.CreateEvent{Object: newPB("instance-b", 1)}) {
+		t.Error("Create event should pass with an empty allowlist")
+	}
+}

--- a/operator/internal/controller/service_account_helper.go
+++ b/operator/internal/controller/service_account_helper.go
@@ -14,6 +14,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+const (
+	// Annotation keys specific to the ServiceAccount flow.
+	AnnotationCreatedBy      = "permission-binder.io/created-by"
+	AnnotationSAType         = "permission-binder.io/sa-type"
+	AnnotationServiceAccount = "permission-binder.io/service-account"
+)
+
 // GenerateServiceAccountName generates a ServiceAccount name based on the pattern
 // Available variables: {namespace}, {name}
 // Default pattern: {namespace}-sa-{name}
@@ -80,16 +87,16 @@ func ProcessServiceAccounts(
 						Name:      fullSAName,
 						Namespace: namespace,
 						Labels: map[string]string{
-							"app.kubernetes.io/managed-by": "permission-binder-operator",
+							"app.kubernetes.io/managed-by": ManagedByValue,
 							"app.kubernetes.io/component":  saName, // deploy, runtime, etc.
 							"app.kubernetes.io/name":       ownerName,
 						},
 						Annotations: map[string]string{
-							"permission-binder.io/created-by":                  "permission-binder-operator",
-							"permission-binder.io/sa-type":                     saName,
-							"permission-binder.io/role":                        roleName,
-							"permission-binder.io/permission-binder":           ownerName,
-							"permission-binder.io/permission-binder-namespace": ownerNamespace,
+							AnnotationCreatedBy:                 ManagedByValue,
+							AnnotationSAType:                    saName,
+							AnnotationRole:                      roleName,
+							AnnotationPermissionBinder:          ownerName,
+							AnnotationPermissionBinderNamespace: ownerNamespace,
 						},
 					},
 				}
@@ -118,6 +125,17 @@ func ProcessServiceAccounts(
 			logger.Info("ServiceAccount already exists, skipping creation",
 				"name", fullSAName,
 				"namespace", namespace)
+			// Visibility only (issue #43): the SA half never mutates existing
+			// objects, but flag when a foreign-claimed SA is treated as satisfied.
+			if sa.Annotations[AnnotationPermissionBinder] != "" && !isOwnedBy(sa.Annotations, ownerName, ownerNamespace) {
+				logger.Info("Existing ServiceAccount is claimed by another PermissionBinder - treating as satisfied without taking ownership",
+					"name", fullSAName,
+					"namespace", namespace,
+					"claimedBy", sa.Annotations[AnnotationPermissionBinder],
+					"claimedByNamespace", sa.Annotations[AnnotationPermissionBinderNamespace],
+					"reconciledBy", ownerName,
+					"reconciledByNamespace", ownerNamespace)
+			}
 		}
 
 		// 2. Create or update RoleBinding for ServiceAccount
@@ -145,16 +163,16 @@ func ProcessServiceAccounts(
 						Name:      roleBindingName,
 						Namespace: namespace,
 						Labels: map[string]string{
-							"app.kubernetes.io/managed-by": "permission-binder-operator",
+							"app.kubernetes.io/managed-by": ManagedByValue,
 							"app.kubernetes.io/component":  "service-account-binding",
 							"app.kubernetes.io/name":       ownerName,
 						},
 						Annotations: map[string]string{
-							"permission-binder.io/created-by":                  "permission-binder-operator",
-							"permission-binder.io/service-account":             fullSAName,
-							"permission-binder.io/sa-type":                     saName,
-							"permission-binder.io/permission-binder":           ownerName,
-							"permission-binder.io/permission-binder-namespace": ownerNamespace,
+							AnnotationCreatedBy:                 ManagedByValue,
+							AnnotationServiceAccount:            fullSAName,
+							AnnotationSAType:                    saName,
+							AnnotationPermissionBinder:          ownerName,
+							AnnotationPermissionBinderNamespace: ownerNamespace,
 						},
 					},
 					RoleRef: rbacv1.RoleRef{
@@ -193,6 +211,26 @@ func ProcessServiceAccounts(
 				return processedSAs, err
 			}
 		} else {
+			// OWNERSHIP GATE (issue #43): a RoleBinding with a live claim by
+			// another PermissionBinder is excluded from this CR's processing
+			// entirely - not deleted/recreated on drift and not counted in
+			// processedSAs/status either (consistent exclusion, no metric
+			// flapping when the mapping later changes). SA RoleBindings are
+			// never orphan-annotated (SAFE-MODE cleanup selects by
+			// LabelManagedBy, which they do not carry), so only unclaimed,
+			// own and legacy name-only RoleBindings are manageable here.
+			if !canTakeOwnership(rb.Annotations, ownerName, ownerNamespace) {
+				ownershipConflictsTotal.WithLabelValues("serviceaccount_rolebinding").Inc()
+				logger.Info("Refusing to take ownership of ServiceAccount RoleBinding claimed by another PermissionBinder",
+					"roleBinding", roleBindingName,
+					"namespace", namespace,
+					"claimedBy", rb.Annotations[AnnotationPermissionBinder],
+					"claimedByNamespace", rb.Annotations[AnnotationPermissionBinderNamespace],
+					"reconciledBy", ownerName,
+					"reconciledByNamespace", ownerNamespace)
+				continue
+			}
+
 			// RoleBinding exists, check if it needs update
 			needsUpdate := false
 
@@ -210,6 +248,32 @@ func ProcessServiceAccounts(
 				logger.Info("RoleBinding subject changed, needs update",
 					"roleBinding", roleBindingName)
 				needsUpdate = true
+			}
+
+			// Legacy RoleBindings (name-only or missing ownership annotations)
+			// are re-stamped in place on first reconcile, so the
+			// namespace-aware takeover protection engages immediately after
+			// upgrade instead of only when the role mapping changes (issue #43
+			// upgrade asymmetry). Annotation-only changes use a plain Update -
+			// delete+recreate would briefly drop the granted permissions.
+			stampOutdated := rb.Annotations[AnnotationPermissionBinderNamespace] != ownerNamespace ||
+				rb.Annotations[AnnotationPermissionBinder] != ownerName
+
+			if !needsUpdate && stampOutdated {
+				if rb.Annotations == nil {
+					rb.Annotations = make(map[string]string)
+				}
+				rb.Annotations[AnnotationPermissionBinder] = ownerName
+				rb.Annotations[AnnotationPermissionBinderNamespace] = ownerNamespace
+				if err := k8sClient.Update(ctx, rb); err != nil {
+					logger.Error(err, "Failed to re-stamp ownership annotations on RoleBinding",
+						"roleBinding", roleBindingName,
+						"namespace", namespace)
+					return processedSAs, err
+				}
+				logger.Info("Re-stamped ownership annotations on legacy RoleBinding",
+					"roleBinding", roleBindingName,
+					"namespace", namespace)
 			}
 
 			if needsUpdate {
@@ -231,16 +295,16 @@ func ProcessServiceAccounts(
 						Name:      roleBindingName,
 						Namespace: namespace,
 						Labels: map[string]string{
-							"app.kubernetes.io/managed-by": "permission-binder-operator",
+							"app.kubernetes.io/managed-by": ManagedByValue,
 							"app.kubernetes.io/component":  "service-account-binding",
 							"app.kubernetes.io/name":       ownerName,
 						},
 						Annotations: map[string]string{
-							"permission-binder.io/created-by":                  "permission-binder-operator",
-							"permission-binder.io/service-account":             fullSAName,
-							"permission-binder.io/sa-type":                     saName,
-							"permission-binder.io/permission-binder":           ownerName,
-							"permission-binder.io/permission-binder-namespace": ownerNamespace,
+							AnnotationCreatedBy:                 ManagedByValue,
+							AnnotationServiceAccount:            fullSAName,
+							AnnotationSAType:                    saName,
+							AnnotationPermissionBinder:          ownerName,
+							AnnotationPermissionBinderNamespace: ownerNamespace,
 						},
 					},
 					RoleRef: rbacv1.RoleRef{

--- a/operator/internal/controller/service_account_helper_test.go
+++ b/operator/internal/controller/service_account_helper_test.go
@@ -1,7 +1,17 @@
 package controller
 
 import (
+	"context"
 	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 // TestGenerateServiceAccountName tests the GenerateServiceAccountName function
@@ -437,5 +447,184 @@ func BenchmarkGenerateServiceAccountName_LongNames(b *testing.B) {
 			"this-is-a-very-long-namespace-name-with-many-segments",
 			"very-long-service-account-name",
 		)
+	}
+}
+
+// ============================================================================
+// ProcessServiceAccounts tests (fake K8s client) - issue #43 ownership gate
+// ============================================================================
+
+func newSAFakeClient(objs ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		Build()
+}
+
+func saRoleBindingFixture(namespace, saName, roleName string, annotations map[string]string) *rbacv1.RoleBinding {
+	fullSAName := GenerateServiceAccountName("", namespace, saName)
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "sa-" + namespace + "-" + saName,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     roleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{Kind: "ServiceAccount", Name: fullSAName, Namespace: namespace},
+		},
+	}
+}
+
+// TestProcessServiceAccounts_ForeignOwnedRoleBindingNotStolen verifies the
+// issue #43 gate: an SA RoleBinding claimed by ANOTHER PermissionBinder must
+// not be delete+recreated even when its RoleRef differs from the mapping.
+func TestProcessServiceAccounts_ForeignOwnedRoleBindingNotStolen(t *testing.T) {
+	const ns = "team-a"
+	existing := saRoleBindingFixture(ns, "deploy", "view", map[string]string{
+		AnnotationPermissionBinder:          "other-binder",
+		AnnotationPermissionBinderNamespace: "other-namespace",
+	})
+	k8sClient := newSAFakeClient(existing)
+
+	conflictsBefore := testutil.ToFloat64(ownershipConflictsTotal.WithLabelValues("serviceaccount_rolebinding"))
+
+	processed, err := ProcessServiceAccounts(context.Background(), k8sClient, ns,
+		map[string]string{"deploy": "edit"}, "", "my-binder", "my-namespace")
+	if err != nil {
+		t.Fatalf("ProcessServiceAccounts returned error: %v", err)
+	}
+
+	var rb rbacv1.RoleBinding
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "sa-" + ns + "-deploy", Namespace: ns}, &rb); err != nil {
+		t.Fatalf("RoleBinding disappeared - it was stolen/deleted: %v", err)
+	}
+	if rb.RoleRef.Name != "view" {
+		t.Errorf("RoleBinding RoleRef was overwritten: expected view, got %s", rb.RoleRef.Name)
+	}
+	if rb.Annotations[AnnotationPermissionBinder] != "other-binder" ||
+		rb.Annotations[AnnotationPermissionBinderNamespace] != "other-namespace" {
+		t.Errorf("Foreign ownership annotations were rewritten: %v", rb.Annotations)
+	}
+	if len(processed) != 0 {
+		t.Errorf("Refused RoleBinding must not be reported as processed, got %v", processed)
+	}
+
+	conflictsAfter := testutil.ToFloat64(ownershipConflictsTotal.WithLabelValues("serviceaccount_rolebinding"))
+	if conflictsAfter != conflictsBefore+1 {
+		t.Errorf("Expected ownership conflict counter to increase by 1, got %v -> %v", conflictsBefore, conflictsAfter)
+	}
+}
+
+// TestProcessServiceAccounts_OwnedRoleBindingRoleChangeRecreated verifies the
+// pre-existing behavior survives the gate: a RoleBinding owned by the calling
+// PermissionBinder IS delete+recreated when the mapped role changes.
+func TestProcessServiceAccounts_OwnedRoleBindingRoleChangeRecreated(t *testing.T) {
+	const ns = "team-a"
+	existing := saRoleBindingFixture(ns, "deploy", "view", map[string]string{
+		AnnotationPermissionBinder:          "my-binder",
+		AnnotationPermissionBinderNamespace: "my-namespace",
+	})
+	k8sClient := newSAFakeClient(existing)
+
+	processed, err := ProcessServiceAccounts(context.Background(), k8sClient, ns,
+		map[string]string{"deploy": "edit"}, "", "my-binder", "my-namespace")
+	if err != nil {
+		t.Fatalf("ProcessServiceAccounts returned error: %v", err)
+	}
+
+	var rb rbacv1.RoleBinding
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "sa-" + ns + "-deploy", Namespace: ns}, &rb); err != nil {
+		t.Fatalf("RoleBinding not found after update: %v", err)
+	}
+	if rb.RoleRef.Name != "edit" {
+		t.Errorf("Owned RoleBinding was not updated: expected edit, got %s", rb.RoleRef.Name)
+	}
+	if rb.Annotations[AnnotationPermissionBinder] != "my-binder" ||
+		rb.Annotations[AnnotationPermissionBinderNamespace] != "my-namespace" {
+		t.Errorf("Ownership annotations missing after recreate: %v", rb.Annotations)
+	}
+	if len(processed) != 1 {
+		t.Errorf("Expected 1 processed SA, got %v", processed)
+	}
+}
+
+// TestProcessServiceAccounts_LegacyNameOnlyRoleBindingTakeable verifies
+// backward compatibility: a legacy RoleBinding annotated with the owner name
+// only (no namespace annotation) is still updated, and the recreate stamps the
+// namespace annotation retroactively.
+func TestProcessServiceAccounts_LegacyNameOnlyRoleBindingTakeable(t *testing.T) {
+	const ns = "team-a"
+	existing := saRoleBindingFixture(ns, "deploy", "view", map[string]string{
+		AnnotationPermissionBinder: "my-binder", // legacy: no namespace annotation
+	})
+	k8sClient := newSAFakeClient(existing)
+
+	if _, err := ProcessServiceAccounts(context.Background(), k8sClient, ns,
+		map[string]string{"deploy": "edit"}, "", "my-binder", "my-namespace"); err != nil {
+		t.Fatalf("ProcessServiceAccounts returned error: %v", err)
+	}
+
+	var rb rbacv1.RoleBinding
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "sa-" + ns + "-deploy", Namespace: ns}, &rb); err != nil {
+		t.Fatalf("RoleBinding not found after update: %v", err)
+	}
+	if rb.RoleRef.Name != "edit" {
+		t.Errorf("Legacy-owned RoleBinding was not updated: expected edit, got %s", rb.RoleRef.Name)
+	}
+	if rb.Annotations[AnnotationPermissionBinderNamespace] != "my-namespace" {
+		t.Errorf("Namespace annotation not stamped retroactively on legacy RoleBinding: %v", rb.Annotations)
+	}
+}
+
+// TestProcessServiceAccounts_ManagedByValueOverrideStamping verifies that an
+// overridden MANAGED_BY_VALUE is actually stamped on created ServiceAccounts
+// and RoleBindings (issue #43: the SA flow used to hardcode the default).
+func TestProcessServiceAccounts_ManagedByValueOverrideStamping(t *testing.T) {
+	original := ManagedByValue
+	t.Cleanup(func() { ManagedByValue = original })
+	ManagedByValue = "permission-binder-operator-e2e-7"
+
+	const ns = "team-a"
+	k8sClient := newSAFakeClient()
+
+	if _, err := ProcessServiceAccounts(context.Background(), k8sClient, ns,
+		map[string]string{"deploy": "edit"}, "", "my-binder", "my-namespace"); err != nil {
+		t.Fatalf("ProcessServiceAccounts returned error: %v", err)
+	}
+
+	fullSAName := GenerateServiceAccountName("", ns, "deploy")
+	var sa corev1.ServiceAccount
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: fullSAName, Namespace: ns}, &sa); err != nil {
+		t.Fatalf("ServiceAccount not created: %v", err)
+	}
+	if got := sa.Labels["app.kubernetes.io/managed-by"]; got != "permission-binder-operator-e2e-7" {
+		t.Errorf("SA managed-by label ignores MANAGED_BY_VALUE override: %q", got)
+	}
+	if got := sa.Annotations[AnnotationCreatedBy]; got != "permission-binder-operator-e2e-7" {
+		t.Errorf("SA created-by annotation ignores MANAGED_BY_VALUE override: %q", got)
+	}
+	if sa.Annotations[AnnotationPermissionBinder] != "my-binder" ||
+		sa.Annotations[AnnotationPermissionBinderNamespace] != "my-namespace" {
+		t.Errorf("SA ownership annotations wrong: %v", sa.Annotations)
+	}
+
+	var rb rbacv1.RoleBinding
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "sa-" + ns + "-deploy", Namespace: ns}, &rb); err != nil {
+		t.Fatalf("RoleBinding not created: %v", err)
+	}
+	if got := rb.Labels["app.kubernetes.io/managed-by"]; got != "permission-binder-operator-e2e-7" {
+		t.Errorf("RB managed-by label ignores MANAGED_BY_VALUE override: %q", got)
+	}
+	if got := rb.Annotations[AnnotationCreatedBy]; got != "permission-binder-operator-e2e-7" {
+		t.Errorf("RB created-by annotation ignores MANAGED_BY_VALUE override: %q", got)
 	}
 }


### PR DESCRIPTION
Implements all three operational gaps + the minors from #43 (post-merge audit of #38).

## 1. Symmetric ownership enforcement (steal-then-delete fix)

The three write paths that adopted unconditionally — `ensureNamespace` update branch, `createRoleBinding` update branch, and the ServiceAccount RoleBinding delete+recreate — now go through `canTakeOwnership()`: a resource carrying a **live claim by another PermissionBinder** is refused (logged + counted in the new `permission_binder_ownership_conflicts_total{resource_type}` metric, excluded from `processedRoleBindings`/`processedSAs` and success metrics). Unclaimed, own, legacy name-only and explicitly orphaned resources remain adoptable. The gate is **annotation-based only** — manual spec drift on an OWNED resource is still reverted (e2e test 15 semantics preserved).

## 2. `RECONCILE_NAMESPACES` — CR scoping that works with dynamic namespaces

New env (comma-separated CR namespaces; empty = all): filters **which PermissionBinder CRs** the instance reconciles without scoping the cache, so whitelist-driven target namespaces stay visible (the reason `WATCH_NAMESPACE` is unusable for e2e/dynamic onboarding). Enforced at four layers: watch predicate (all 4 event funcs), ConfigMap mapping handler, `isConfigMapReferenced`, and a `Reconcile()` backstop; `CheckMultiplePermissionBinders` is scoped too. This is the knob that makes `MANAGED_BY_VALUE` actually safe — documented as coupled, with a startup warning when an entry falls outside `WATCH_NAMESPACE`. The e2e runner injects `RECONCILE_NAMESPACES=$NAMESPACE` per instance.

## 3. Documentation

`WATCH_NAMESPACE` hard enumeration requirement (CR ns + `configMapNamespace` + all target namespaces **+ Secret namespaces** from `ldapSecretRef`/git `credentialsSecretRef`; namespace-scoped reads hard-fail, cluster-wide label Lists silently omit), MANAGED_BY_VALUE coupling, scoping footguns (subset rule, stuck finalizer on narrowed scope, legacy first-stamp-wins), and a **CR namespace-migration path** (SAFE-MODE orphan → recreate → re-adopt) with the stale-grants warning and SA caveats. Metrics catalog: 16.

## Minors from the issue

- `pb.Namespace==""` name-only fallback removed (strict matching; empty-value stamps degrade to legacy name matching instead of permanently wedging a resource)
- `service_account_helper` uses shared constants + `ManagedByValue` (SA flow now honors the override); legacy SA RoleBindings re-stamped **in place** on first reconcile (no permission-dropping delete+recreate for annotation-only changes)
- orphan annotation strings promoted to constants
- ownership/scoping test coverage: gate matrix, strict/degenerate stamps, predicate scoping (4 event types), `CheckMultiplePermissionBinders` metric-delta test, SA conflict/override paths

## Verification

- Full hermetic unit suite green on the branch (build / vet / gofmt clean).
- Adversarially reviewed pre-commit (4 independent lenses: gate correctness, scoping completeness, default-path regressions, docs accuracy): **0 blockers**; both majors (docs) and all actionable minors fixed in this PR. Confirmed clean: default-path behavior bit-identical with envs unset; all annotation writes gated or create-only; every PB enqueue/list path covered by the allowlist; e2e tests 07/10/14/15/30/33/40/41 semantics preserved (test-37 adjusted — namespace enumeration via SA labels, since secondary CRs can no longer own shared namespaces).
- Known intended behavior change: two CRs contesting the same resource are now **first-owner-wins** (previously last-writer-wins); refusals are observable via the conflict metric and logs.

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)
