### PR TITLE
fix: SA status poison on partial processing + stale-cache AlreadyExists + client rate limiter restore

### DIFF
--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -294,6 +294,7 @@ func main() {
 	if err = (&controller.PermissionBinderReconciler{
 		Client:              mgr.GetClient(),
 		Scheme:              mgr.GetScheme(),
+		APIReader:           mgr.GetAPIReader(),
 		DebugMode:           debugMode,
 		ReconcileNamespaces: reconcileNamespaces,
 	}).SetupWithManager(mgr); err != nil {

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"os"
+	"strconv"
 	"strings"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -63,6 +64,36 @@ func parseWatchNamespaces(value string) []string {
 		}
 	}
 	return namespaces
+}
+
+// envFloat32 reads a float32 from the environment, falling back to def when
+// the variable is unset or unparsable (a warning is logged for the latter).
+func envFloat32(name string, def float32) float32 {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		return def
+	}
+	parsed, err := strconv.ParseFloat(value, 32)
+	if err != nil {
+		setupLog.Info("Ignoring unparsable environment variable", "name", name, "value", value, "default", def)
+		return def
+	}
+	return float32(parsed)
+}
+
+// envInt reads an int from the environment, falling back to def when the
+// variable is unset or unparsable (a warning is logged for the latter).
+func envInt(name string, def int) int {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		return def
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		setupLog.Info("Ignoring unparsable environment variable", "name", name, "value", value, "default", def)
+		return def
+	}
+	return parsed
 }
 
 func init() {
@@ -201,7 +232,18 @@ func main() {
 		setupLog.Info("WATCH_NAMESPACE not set - watching all namespaces")
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), managerOptions)
+	// controller-runtime v0.21 stopped installing a default client-side rate
+	// limiter (was QPS 20 / Burst 30 up to v0.20). Restore that known-good
+	// profile by default so bulk RoleBinding/ServiceAccount writes do not burst
+	// unthrottled against small API servers; override via CLIENT_QPS /
+	// CLIENT_BURST (CLIENT_QPS=-1 disables client-side limiting entirely,
+	// 0 falls back to the client-go default of 5/10).
+	restConfig := ctrl.GetConfigOrDie()
+	restConfig.QPS = envFloat32("CLIENT_QPS", 20)
+	restConfig.Burst = envInt("CLIENT_BURST", 30)
+	setupLog.Info("Client-side rate limiter configured", "qps", restConfig.QPS, "burst", restConfig.Burst)
+
+	mgr, err := ctrl.NewManager(restConfig, managerOptions)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)

--- a/operator/internal/controller/reconciliation_configmap.go
+++ b/operator/internal/controller/reconciliation_configmap.go
@@ -34,6 +34,12 @@ import (
 type ProcessConfigMapResult struct {
 	ProcessedRoleBindings    []string
 	ProcessedServiceAccounts []string
+	// ServiceAccountsError carries the first per-namespace ServiceAccount
+	// processing failure. The reconciler must NOT stamp
+	// LastProcessedConfigMapVersion when it is set: the skip guard would pin
+	// the partial result permanently, because an unchanged ConfigMap never
+	// fires another event to retry the missing pieces.
+	ServiceAccountsError error
 }
 
 // processConfigMap processes the ConfigMap data and creates RoleBindings
@@ -164,9 +170,15 @@ func (r *PermissionBinderReconciler) processConfigMap(ctx context.Context, permi
 				permissionBinder.Namespace,
 			)
 			if err != nil {
-				// Log error but don't fail the entire reconciliation
-				logger.Error(err, "⚠️  ServiceAccount creation failed (non-fatal)",
+				// Keep processing the remaining namespaces (best effort within
+				// this pass), but record the failure so the reconciler skips the
+				// ConfigMap-version stamp and requeues instead of silently
+				// pinning a partial status.
+				logger.Error(err, "⚠️  ServiceAccount creation failed, reconciliation will be retried",
 					"namespace", namespace)
+				if result.ServiceAccountsError == nil {
+					result.ServiceAccountsError = fmt.Errorf("namespace %s: %w", namespace, err)
+				}
 			} else {
 				allProcessedSAs = append(allProcessedSAs, processedSAs...)
 				logger.Info("✅ ServiceAccounts processed successfully",

--- a/operator/internal/controller/reconciliation_configmap.go
+++ b/operator/internal/controller/reconciliation_configmap.go
@@ -34,12 +34,20 @@ import (
 type ProcessConfigMapResult struct {
 	ProcessedRoleBindings    []string
 	ProcessedServiceAccounts []string
-	// ServiceAccountsError carries the first per-namespace ServiceAccount
-	// processing failure. The reconciler must NOT stamp
+	// IncompleteError carries the first entry-level failure from ANY of the
+	// three processing loops (ensureNamespace, createRoleBinding,
+	// ProcessServiceAccounts). The reconciler must NOT stamp
 	// LastProcessedConfigMapVersion when it is set: the skip guard would pin
 	// the partial result permanently, because an unchanged ConfigMap never
-	// fires another event to retry the missing pieces.
-	ServiceAccountsError error
+	// fires another event to retry the dropped entries.
+	IncompleteError error
+}
+
+// recordIncomplete keeps the first entry-level failure of the pass.
+func (result *ProcessConfigMapResult) recordIncomplete(err error) {
+	if result.IncompleteError == nil {
+		result.IncompleteError = err
+	}
 }
 
 // processConfigMap processes the ConfigMap data and creates RoleBindings
@@ -105,7 +113,8 @@ func (r *PermissionBinderReconciler) processConfigMap(ctx context.Context, permi
 
 		// Ensure namespace exists
 		if err := r.ensureNamespace(ctx, namespace, permissionBinder); err != nil {
-			logger.Error(err, "Failed to ensure namespace exists", "namespace", namespace)
+			logger.Error(err, "Failed to ensure namespace exists, entry will be retried", "namespace", namespace)
+			result.recordIncomplete(fmt.Errorf("namespace %s: %w", namespace, err))
 			continue
 		}
 
@@ -114,7 +123,8 @@ func (r *PermissionBinderReconciler) processConfigMap(ctx context.Context, permi
 		roleBindingName := fmt.Sprintf("%s-%s", namespace, role)
 		managed, err := r.createRoleBinding(ctx, namespace, roleBindingName, role, cnValue, permissionBinder.Spec.RoleMapping[role], permissionBinder)
 		if err != nil {
-			logger.Error(err, "Failed to create RoleBinding", "namespace", namespace, "role", role)
+			logger.Error(err, "Failed to create RoleBinding, entry will be retried", "namespace", namespace, "role", role)
+			result.recordIncomplete(fmt.Errorf("rolebinding %s/%s: %w", namespace, roleBindingName, err))
 			continue
 		}
 		if !managed {
@@ -176,9 +186,7 @@ func (r *PermissionBinderReconciler) processConfigMap(ctx context.Context, permi
 				// pinning a partial status.
 				logger.Error(err, "⚠️  ServiceAccount creation failed, reconciliation will be retried",
 					"namespace", namespace)
-				if result.ServiceAccountsError == nil {
-					result.ServiceAccountsError = fmt.Errorf("namespace %s: %w", namespace, err)
-				}
+				result.recordIncomplete(fmt.Errorf("serviceaccounts in namespace %s: %w", namespace, err))
 			} else {
 				allProcessedSAs = append(allProcessedSAs, processedSAs...)
 				logger.Info("✅ ServiceAccounts processed successfully",

--- a/operator/internal/controller/reconciliation_main.go
+++ b/operator/internal/controller/reconciliation_main.go
@@ -443,7 +443,11 @@ func (r *PermissionBinderReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		conditionMessage = fmt.Sprintf("Processed %d role bindings; ServiceAccount processing incomplete (retrying): %v", len(newProcessedRoleBindings), result.ServiceAccountsError)
 	}
 	existingCondition := findCondition(permissionBinder.Status.Conditions, "Processed")
-	if existingCondition == nil || existingCondition.Status != conditionStatus || existingCondition.Message != conditionMessage {
+	if existingCondition == nil || existingCondition.Status != conditionStatus || existingCondition.Message != conditionMessage ||
+		existingCondition.ObservedGeneration != permissionBinder.Generation {
+		// ObservedGeneration is part of the condition contract consumers wait
+		// on (e2e test 35 matches type + observedGeneration): a generation
+		// bump must refresh the condition even when nothing else changed.
 		statusChanged = true
 	}
 

--- a/operator/internal/controller/reconciliation_main.go
+++ b/operator/internal/controller/reconciliation_main.go
@@ -386,6 +386,17 @@ func (r *PermissionBinderReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}
 
+	// Partial ServiceAccount processing must never be stamped into status:
+	// with LastProcessedConfigMapVersion set, the skip guard would pin the
+	// partial result permanently (an unchanged ConfigMap fires no further
+	// events). Leave status untouched and requeue with backoff - the retry
+	// reprocesses the same ConfigMap version and completes the missing pieces.
+	if result.ServiceAccountsError != nil {
+		logger.Error(result.ServiceAccountsError,
+			"ServiceAccount processing incomplete - skipping status update and requeuing")
+		return ctrl.Result{}, result.ServiceAccountsError
+	}
+
 	// Prepare new status values
 	newProcessedRoleBindings := result.ProcessedRoleBindings
 	newProcessedServiceAccounts := result.ProcessedServiceAccounts

--- a/operator/internal/controller/reconciliation_main.go
+++ b/operator/internal/controller/reconciliation_main.go
@@ -386,17 +386,6 @@ func (r *PermissionBinderReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}
 
-	// Partial ServiceAccount processing must never be stamped into status:
-	// with LastProcessedConfigMapVersion set, the skip guard would pin the
-	// partial result permanently (an unchanged ConfigMap fires no further
-	// events). Leave status untouched and requeue with backoff - the retry
-	// reprocesses the same ConfigMap version and completes the missing pieces.
-	if result.ServiceAccountsError != nil {
-		logger.Error(result.ServiceAccountsError,
-			"ServiceAccount processing incomplete - skipping status update and requeuing")
-		return ctrl.Result{}, result.ServiceAccountsError
-	}
-
 	// Prepare new status values
 	newProcessedRoleBindings := result.ProcessedRoleBindings
 	newProcessedServiceAccounts := result.ProcessedServiceAccounts
@@ -404,6 +393,20 @@ func (r *PermissionBinderReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	newRoleMappingHash := permissionBinder.Status.LastProcessedRoleMappingHash
 	if roleMappingChanged {
 		newRoleMappingHash = currentHash
+	}
+
+	// Partial ServiceAccount processing must never be stamped into status:
+	// with LastProcessedConfigMapVersion set, the skip guard would pin the
+	// partial result permanently (an unchanged ConfigMap fires no further
+	// events to retry the missing pieces). Keep the previous ConfigMap
+	// version, role-mapping hash and ServiceAccount list (this pass's list is
+	// incomplete), but still publish RoleBindings and a Processed=False
+	// condition so the CR stays observable under persistent failures. The
+	// error return at the end requeues the reconcile with backoff.
+	if result.ServiceAccountsError != nil {
+		newProcessedServiceAccounts = permissionBinder.Status.ProcessedServiceAccounts
+		newConfigMapVersion = permissionBinder.Status.LastProcessedConfigMapVersion
+		newRoleMappingHash = permissionBinder.Status.LastProcessedRoleMappingHash
 	}
 
 	// Check if status actually changed before updating
@@ -431,9 +434,16 @@ func (r *PermissionBinderReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	// Check if Conditions need update (only update LastTransitionTime if status changed)
+	conditionStatus := metav1.ConditionTrue
+	conditionReason := "ConfigMapProcessed"
 	conditionMessage := fmt.Sprintf("Successfully processed %d role bindings and %d service accounts", len(newProcessedRoleBindings), len(newProcessedServiceAccounts))
+	if result.ServiceAccountsError != nil {
+		conditionStatus = metav1.ConditionFalse
+		conditionReason = "ServiceAccountProcessingIncomplete"
+		conditionMessage = fmt.Sprintf("Processed %d role bindings; ServiceAccount processing incomplete (retrying): %v", len(newProcessedRoleBindings), result.ServiceAccountsError)
+	}
 	existingCondition := findCondition(permissionBinder.Status.Conditions, "Processed")
-	if existingCondition == nil || existingCondition.Status != metav1.ConditionTrue || existingCondition.Message != conditionMessage {
+	if existingCondition == nil || existingCondition.Status != conditionStatus || existingCondition.Message != conditionMessage {
 		statusChanged = true
 	}
 
@@ -454,31 +464,20 @@ func (r *PermissionBinderReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		permissionBinder.Status.LastProcessedRoleMappingHash = newRoleMappingHash
 
 		// Update Conditions - preserve LastTransitionTime if condition already exists with same status
-		now := metav1.Now()
-		if existingCondition != nil && existingCondition.Status == metav1.ConditionTrue && existingCondition.Message == conditionMessage {
+		transitionTime := metav1.Now()
+		if existingCondition != nil && existingCondition.Status == conditionStatus && existingCondition.Message == conditionMessage {
 			// Condition already exists with same status, preserve LastTransitionTime
-			permissionBinder.Status.Conditions = []metav1.Condition{
-				{
-					Type:               "Processed",
-					Status:             metav1.ConditionTrue,
-					LastTransitionTime: existingCondition.LastTransitionTime, // Preserve original time
-					Reason:             "ConfigMapProcessed",
-					Message:            conditionMessage,
-					ObservedGeneration: permissionBinder.Generation,
-				},
-			}
-		} else {
-			// New condition or status changed, use current time
-			permissionBinder.Status.Conditions = []metav1.Condition{
-				{
-					Type:               "Processed",
-					Status:             metav1.ConditionTrue,
-					LastTransitionTime: now,
-					Reason:             "ConfigMapProcessed",
-					Message:            conditionMessage,
-					ObservedGeneration: permissionBinder.Generation,
-				},
-			}
+			transitionTime = existingCondition.LastTransitionTime
+		}
+		permissionBinder.Status.Conditions = []metav1.Condition{
+			{
+				Type:               "Processed",
+				Status:             conditionStatus,
+				LastTransitionTime: transitionTime,
+				Reason:             conditionReason,
+				Message:            conditionMessage,
+				ObservedGeneration: permissionBinder.Generation,
+			},
 		}
 
 		if err := r.Status().Update(ctx, &permissionBinder); err != nil {
@@ -499,6 +498,15 @@ func (r *PermissionBinderReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if err := r.updateMetrics(ctx, &permissionBinder); err != nil {
 		logger.Error(err, "Failed to update metrics (non-fatal)")
 		// Don't fail reconciliation on metrics error
+	}
+
+	// Requeue on partial ServiceAccount processing: the ConfigMap version was
+	// deliberately not stamped above, so the retry reprocesses it and
+	// completes the missing pieces.
+	if result.ServiceAccountsError != nil {
+		logger.Error(result.ServiceAccountsError,
+			"ServiceAccount processing incomplete - partial status published without ConfigMap version stamp, requeuing")
+		return ctrl.Result{}, result.ServiceAccountsError
 	}
 
 	logger.Info("Successfully processed ConfigMap",

--- a/operator/internal/controller/reconciliation_main.go
+++ b/operator/internal/controller/reconciliation_main.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -80,6 +81,11 @@ type PermissionBinderReconciler struct {
 	client.Client
 	Scheme    *runtime.Scheme
 	DebugMode bool
+	// APIReader reads directly from the API server, bypassing the informer
+	// cache. Used to re-read objects after a Create returned AlreadyExists on
+	// a stale cached Get, and to re-fetch the CR on status-update conflicts.
+	// Optional: falls back to the (cached) Client when unset (unit tests).
+	APIReader client.Reader
 	// ReconcileNamespaces optionally restricts which PermissionBinder CRs this
 	// instance reconciles, by CR namespace (RECONCILE_NAMESPACES env,
 	// comma-separated). Empty = reconcile CRs from all namespaces (default).
@@ -87,6 +93,15 @@ type PermissionBinderReconciler struct {
 	// created target namespaces stay visible - this is the knob that makes
 	// MANAGED_BY_VALUE safe in multi-instance deployments.
 	ReconcileNamespaces []string
+}
+
+// uncachedReader returns the direct API reader when configured, falling back
+// to the regular (cached) client otherwise.
+func (r *PermissionBinderReconciler) uncachedReader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
 }
 
 // reconcilesNamespace reports whether this instance reconciles PermissionBinder
@@ -395,15 +410,17 @@ func (r *PermissionBinderReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		newRoleMappingHash = currentHash
 	}
 
-	// Partial ServiceAccount processing must never be stamped into status:
-	// with LastProcessedConfigMapVersion set, the skip guard would pin the
-	// partial result permanently (an unchanged ConfigMap fires no further
-	// events to retry the missing pieces). Keep the previous ConfigMap
-	// version, role-mapping hash and ServiceAccount list (this pass's list is
-	// incomplete), but still publish RoleBindings and a Processed=False
-	// condition so the CR stays observable under persistent failures. The
-	// error return at the end requeues the reconcile with backoff.
-	if result.ServiceAccountsError != nil {
+	// An incomplete pass (dropped whitelist entries or failed ServiceAccounts)
+	// must never be stamped into status: with LastProcessedConfigMapVersion
+	// set, the skip guard would pin the partial result permanently (an
+	// unchanged ConfigMap fires no further events to retry the dropped
+	// pieces). Keep the previous ConfigMap version, role-mapping hash and
+	// resource lists (this pass's lists are lower bounds, publishing them
+	// would shrink a previously-complete status), but still publish a
+	// Processed=False condition so the CR stays observable under persistent
+	// failures. The error return at the end requeues the reconcile.
+	if result.IncompleteError != nil {
+		newProcessedRoleBindings = permissionBinder.Status.ProcessedRoleBindings
 		newProcessedServiceAccounts = permissionBinder.Status.ProcessedServiceAccounts
 		newConfigMapVersion = permissionBinder.Status.LastProcessedConfigMapVersion
 		newRoleMappingHash = permissionBinder.Status.LastProcessedRoleMappingHash
@@ -437,10 +454,10 @@ func (r *PermissionBinderReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	conditionStatus := metav1.ConditionTrue
 	conditionReason := "ConfigMapProcessed"
 	conditionMessage := fmt.Sprintf("Successfully processed %d role bindings and %d service accounts", len(newProcessedRoleBindings), len(newProcessedServiceAccounts))
-	if result.ServiceAccountsError != nil {
+	if result.IncompleteError != nil {
 		conditionStatus = metav1.ConditionFalse
-		conditionReason = "ServiceAccountProcessingIncomplete"
-		conditionMessage = fmt.Sprintf("Processed %d role bindings; ServiceAccount processing incomplete (retrying): %v", len(newProcessedRoleBindings), result.ServiceAccountsError)
+		conditionReason = "ProcessingIncomplete"
+		conditionMessage = fmt.Sprintf("Reconciliation incomplete (retrying): %v", result.IncompleteError)
 	}
 	existingCondition := findCondition(permissionBinder.Status.Conditions, "Processed")
 	if existingCondition == nil || existingCondition.Status != conditionStatus || existingCondition.Message != conditionMessage ||
@@ -484,7 +501,22 @@ func (r *PermissionBinderReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			},
 		}
 
-		if err := r.Status().Update(ctx, &permissionBinder); err != nil {
+		// Retry conflicts in place with an uncached re-fetch: a failed/retried
+		// status write is the pass-1 trigger of the stale-cache wedge (the
+		// priority queue retries within milliseconds, before informers catch
+		// up), so resolving the conflict here avoids a whole extra pass.
+		desiredStatus := permissionBinder.Status
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			updateErr := r.Status().Update(ctx, &permissionBinder)
+			if updateErr != nil && errors.IsConflict(updateErr) {
+				var fresh permissionv1.PermissionBinder
+				if getErr := r.uncachedReader().Get(ctx, req.NamespacedName, &fresh); getErr == nil {
+					fresh.Status = desiredStatus
+					permissionBinder = fresh
+				}
+			}
+			return updateErr
+		}); err != nil {
 			logger.Error(err, "Failed to update PermissionBinder status")
 			return ctrl.Result{}, err
 		}
@@ -504,13 +536,13 @@ func (r *PermissionBinderReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		// Don't fail reconciliation on metrics error
 	}
 
-	// Requeue on partial ServiceAccount processing: the ConfigMap version was
-	// deliberately not stamped above, so the retry reprocesses it and
-	// completes the missing pieces.
-	if result.ServiceAccountsError != nil {
-		logger.Error(result.ServiceAccountsError,
-			"ServiceAccount processing incomplete - partial status published without ConfigMap version stamp, requeuing")
-		return ctrl.Result{}, result.ServiceAccountsError
+	// Requeue on an incomplete pass: the ConfigMap version was deliberately
+	// not stamped above, so the retry reprocesses it and completes the
+	// dropped pieces.
+	if result.IncompleteError != nil {
+		logger.Error(result.IncompleteError,
+			"Reconciliation incomplete - status published without ConfigMap version stamp, requeuing")
+		return ctrl.Result{}, result.IncompleteError
 	}
 
 	logger.Info("Successfully processed ConfigMap",

--- a/operator/internal/controller/reconciliation_rolebindings.go
+++ b/operator/internal/controller/reconciliation_rolebindings.go
@@ -55,13 +55,28 @@ func (r *PermissionBinderReconciler) ensureNamespace(ctx context.Context, namesp
 					},
 				},
 			}
-			if err := r.Create(ctx, &ns); err != nil {
-				return fmt.Errorf("failed to create namespace %s: %w", namespace, err)
+			createErr := r.Create(ctx, &ns)
+			if createErr == nil {
+				return nil
+			}
+			if !errors.IsAlreadyExists(createErr) {
+				return fmt.Errorf("failed to create namespace %s: %w", namespace, createErr)
+			}
+			// AlreadyExists = the cached Get above was stale (informer lag):
+			// the namespace is present server-side. Re-read it uncached and
+			// fall through to the ownership/annotation path below - dropping
+			// the entry here would exclude its RoleBinding and ServiceAccounts
+			// from the whole pass.
+			logger.Info("Namespace already exists (stale cache read), re-reading uncached",
+				"namespace", namespace)
+			if err := r.uncachedReader().Get(ctx, types.NamespacedName{Name: namespace}, &ns); err != nil {
+				return fmt.Errorf("failed to re-read namespace %s after AlreadyExists: %w", namespace, err)
 			}
 		} else {
 			return fmt.Errorf("failed to get namespace %s: %w", namespace, err)
 		}
-	} else {
+	}
+	{
 		// OWNERSHIP GATE (issue #43): never take over a namespace with a live
 		// claim by another PermissionBinder. Unclaimed, own, legacy name-only
 		// and explicitly orphaned namespaces remain adoptable.
@@ -215,13 +230,28 @@ func (r *PermissionBinderReconciler) createRoleBinding(ctx context.Context, name
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Create new RoleBinding
-			if err := r.Create(ctx, roleBinding); err != nil {
-				return false, fmt.Errorf("failed to create RoleBinding %s/%s: %w", namespace, name, err)
+			createErr := r.Create(ctx, roleBinding)
+			if createErr == nil {
+				return true, nil
+			}
+			if !errors.IsAlreadyExists(createErr) {
+				return false, fmt.Errorf("failed to create RoleBinding %s/%s: %w", namespace, name, createErr)
+			}
+			// AlreadyExists = the cached Get above was stale (informer lag):
+			// the RoleBinding is present server-side. Re-read it uncached and
+			// fall through to the ownership/update path below - dropping the
+			// entry here would exclude it from processedRoleBindings and
+			// suppress the namespace's ServiceAccounts for the whole pass.
+			logger.Info("RoleBinding already exists (stale cache read), re-reading uncached",
+				"namespace", namespace, "roleBinding", name)
+			if err := r.uncachedReader().Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &existing); err != nil {
+				return false, fmt.Errorf("failed to re-read RoleBinding %s/%s after AlreadyExists: %w", namespace, name, err)
 			}
 		} else {
 			return false, fmt.Errorf("failed to get RoleBinding %s/%s: %w", namespace, name, err)
 		}
-	} else {
+	}
+	{
 		// OWNERSHIP GATE (issue #43): never overwrite a RoleBinding with a live
 		// claim by another PermissionBinder (steal-then-delete prevention).
 		// Gate is annotation-based ONLY - spec drift on an OWNED RoleBinding is

--- a/operator/internal/controller/reconciliation_rolebindings_stale_cache_test.go
+++ b/operator/internal/controller/reconciliation_rolebindings_stale_cache_test.go
@@ -1,0 +1,158 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	permissionv1 "github.com/permission-binder-operator/operator/api/v1"
+)
+
+// ============================================================================
+// Stale-cache AlreadyExists paths (v1.8.0 status-poison fix, entry-drop
+// variant): the cached Get says NotFound while the object exists server-side.
+// Simulated with a shared fake store: Client's Get is intercepted to NotFound
+// (the stale informer view), Create passes through and hits the store's real
+// AlreadyExists, and APIReader is the uninstrumented view (server truth).
+// ============================================================================
+
+func newStaleCacheScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
+	_ = permissionv1.AddToScheme(scheme)
+	return scheme
+}
+
+func staleCacheBinder() *permissionv1.PermissionBinder {
+	return &permissionv1.PermissionBinder{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-binder", Namespace: "my-namespace"},
+	}
+}
+
+// TestEnsureNamespace_AlreadyExistsStaleCache: the namespace exists server-side
+// but the cached Get misses it. ensureNamespace must fall through to the
+// ownership/annotation path via the uncached re-read instead of failing (the
+// caller would drop the whitelist entry for the whole pass).
+func TestEnsureNamespace_AlreadyExistsStaleCache(t *testing.T) {
+	existing := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "team-stale"}}
+	base := fake.NewClientBuilder().WithScheme(newStaleCacheScheme()).WithObjects(existing).Build()
+	staleClient := interceptor.NewClient(base, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, ok := obj.(*corev1.Namespace); ok {
+				return apierrors.NewNotFound(corev1.Resource("namespaces"), key.Name)
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+
+	r := &PermissionBinderReconciler{Client: staleClient, APIReader: base}
+	if err := r.ensureNamespace(context.Background(), "team-stale", staleCacheBinder()); err != nil {
+		t.Fatalf("ensureNamespace must tolerate stale-cache AlreadyExists, got: %v", err)
+	}
+
+	// The exists-path must have run: ownership annotations stamped in place.
+	var ns corev1.Namespace
+	if err := base.Get(context.Background(), types.NamespacedName{Name: "team-stale"}, &ns); err != nil {
+		t.Fatalf("namespace disappeared: %v", err)
+	}
+	if ns.Annotations[AnnotationPermissionBinder] != "my-binder" ||
+		ns.Annotations[AnnotationPermissionBinderNamespace] != "my-namespace" {
+		t.Errorf("ownership annotations not stamped after stale-cache fall-through: %v", ns.Annotations)
+	}
+}
+
+// TestCreateRoleBinding_AlreadyExistsStaleCache: same race on the LDAP-group
+// RoleBinding. Must return managed=true with the ownership/update path applied.
+func TestCreateRoleBinding_AlreadyExistsStaleCache(t *testing.T) {
+	existing := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "team-stale-admin", Namespace: "team-stale"},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "admin",
+		},
+	}
+	base := fake.NewClientBuilder().WithScheme(newStaleCacheScheme()).WithObjects(existing).Build()
+	staleClient := interceptor.NewClient(base, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, ok := obj.(*rbacv1.RoleBinding); ok {
+				return apierrors.NewNotFound(rbacv1.Resource("rolebindings"), key.Name)
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+
+	r := &PermissionBinderReconciler{Client: staleClient, APIReader: base}
+	managed, err := r.createRoleBinding(context.Background(), "team-stale", "team-stale-admin",
+		"admin", "COMPANY-K8S-team-stale-admin", "admin", staleCacheBinder())
+	if err != nil {
+		t.Fatalf("createRoleBinding must tolerate stale-cache AlreadyExists, got: %v", err)
+	}
+	if !managed {
+		t.Fatal("createRoleBinding must report managed=true after stale-cache fall-through")
+	}
+
+	var rb rbacv1.RoleBinding
+	if err := base.Get(context.Background(), types.NamespacedName{Name: "team-stale-admin", Namespace: "team-stale"}, &rb); err != nil {
+		t.Fatalf("RoleBinding disappeared: %v", err)
+	}
+	if rb.Annotations[AnnotationPermissionBinder] != "my-binder" {
+		t.Errorf("ownership annotations not stamped after stale-cache fall-through: %v", rb.Annotations)
+	}
+	if len(rb.Subjects) != 1 || rb.Subjects[0].Name != "COMPANY-K8S-team-stale-admin" {
+		t.Errorf("subjects not enforced on the exists-path: %v", rb.Subjects)
+	}
+}
+
+// TestCreateRoleBinding_ForeignClaimStillRefusedAfterStaleCache: the ownership
+// gate must survive the new fall-through - a foreign-claimed RoleBinding found
+// via the uncached re-read is still refused (managed=false, no mutation).
+func TestCreateRoleBinding_ForeignClaimStillRefusedAfterStaleCache(t *testing.T) {
+	existing := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "team-stale-admin", Namespace: "team-stale",
+			Annotations: map[string]string{
+				AnnotationPermissionBinder:          "other-binder",
+				AnnotationPermissionBinderNamespace: "other-namespace",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "view",
+		},
+	}
+	base := fake.NewClientBuilder().WithScheme(newStaleCacheScheme()).WithObjects(existing).Build()
+	staleClient := interceptor.NewClient(base, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, ok := obj.(*rbacv1.RoleBinding); ok {
+				return apierrors.NewNotFound(rbacv1.Resource("rolebindings"), key.Name)
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+
+	r := &PermissionBinderReconciler{Client: staleClient, APIReader: base}
+	managed, err := r.createRoleBinding(context.Background(), "team-stale", "team-stale-admin",
+		"admin", "COMPANY-K8S-team-stale-admin", "admin", staleCacheBinder())
+	if err != nil {
+		t.Fatalf("foreign claim must be a clean refusal, got error: %v", err)
+	}
+	if managed {
+		t.Fatal("foreign-claimed RoleBinding must NOT be reported managed after stale-cache fall-through")
+	}
+
+	var rb rbacv1.RoleBinding
+	if err := base.Get(context.Background(), types.NamespacedName{Name: "team-stale-admin", Namespace: "team-stale"}, &rb); err != nil {
+		t.Fatalf("RoleBinding disappeared: %v", err)
+	}
+	if rb.RoleRef.Name != "view" {
+		t.Errorf("foreign RoleBinding was mutated: %v", rb.RoleRef)
+	}
+}

--- a/operator/internal/controller/service_account_helper.go
+++ b/operator/internal/controller/service_account_helper.go
@@ -102,18 +102,27 @@ func ProcessServiceAccounts(
 				}
 
 				if err := k8sClient.Create(ctx, newSA); err != nil {
-					logger.Error(err, "Failed to create ServiceAccount",
+					// AlreadyExists means the cached Get above was stale (informer
+					// lag) - the ServiceAccount is present server-side, which is
+					// all this step guarantees. Treat as the idempotent
+					// already-exists case instead of aborting the namespace.
+					if !errors.IsAlreadyExists(err) {
+						logger.Error(err, "Failed to create ServiceAccount",
+							"name", fullSAName,
+							"namespace", namespace)
+						return processedSAs, err
+					}
+					logger.Info("ServiceAccount already exists (stale cache read), continuing",
 						"name", fullSAName,
 						"namespace", namespace)
-					return processedSAs, err
+				} else {
+					logger.Info("ServiceAccount created successfully",
+						"name", fullSAName,
+						"namespace", namespace)
+
+					// Increment metric
+					serviceAccountsCreated.WithLabelValues(namespace, saName).Inc()
 				}
-
-				logger.Info("ServiceAccount created successfully",
-					"name", fullSAName,
-					"namespace", namespace)
-
-				// Increment metric
-				serviceAccountsCreated.WithLabelValues(namespace, saName).Inc()
 			} else {
 				logger.Error(err, "Failed to get ServiceAccount",
 					"name", fullSAName,
@@ -190,18 +199,29 @@ func ProcessServiceAccounts(
 				}
 
 				if err := k8sClient.Create(ctx, newRB); err != nil {
-					logger.Error(err, "Failed to create RoleBinding for ServiceAccount",
+					// AlreadyExists = stale cached Get (informer lag); the
+					// RoleBinding is present server-side. Almost always it is our
+					// own object from a previous reconcile pass - the next pass
+					// takes the exists-branch and applies the full ownership
+					// gate, so a foreign claim is still refused there.
+					if !errors.IsAlreadyExists(err) {
+						logger.Error(err, "Failed to create RoleBinding for ServiceAccount",
+							"roleBinding", roleBindingName,
+							"serviceAccount", fullSAName,
+							"namespace", namespace)
+						return processedSAs, err
+					}
+					logger.Info("RoleBinding for ServiceAccount already exists (stale cache read), continuing",
 						"roleBinding", roleBindingName,
 						"serviceAccount", fullSAName,
 						"namespace", namespace)
-					return processedSAs, err
+				} else {
+					logger.Info("RoleBinding created successfully for ServiceAccount",
+						"roleBinding", roleBindingName,
+						"serviceAccount", fullSAName,
+						"role", roleName,
+						"namespace", namespace)
 				}
-
-				logger.Info("RoleBinding created successfully for ServiceAccount",
-					"roleBinding", roleBindingName,
-					"serviceAccount", fullSAName,
-					"role", roleName,
-					"namespace", namespace)
 
 				// Metrics are updated in controller after processing all namespaces
 			} else {

--- a/operator/internal/controller/service_account_helper_test.go
+++ b/operator/internal/controller/service_account_helper_test.go
@@ -2,16 +2,20 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 // TestGenerateServiceAccountName tests the GenerateServiceAccountName function
@@ -465,6 +469,21 @@ func newSAFakeClient(objs ...client.Object) client.Client {
 		Build()
 }
 
+// newSAFakeClientWithInterceptors mirrors newSAFakeClient but installs
+// interceptor funcs to simulate API-server-side failures the cached client
+// cannot produce on its own (stale-cache AlreadyExists, transient errors).
+func newSAFakeClientWithInterceptors(funcs interceptor.Funcs, objs ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithInterceptorFuncs(funcs).
+		Build()
+}
+
 func saRoleBindingFixture(namespace, saName, roleName string, annotations map[string]string) *rbacv1.RoleBinding {
 	fullSAName := GenerateServiceAccountName("", namespace, saName)
 	return &rbacv1.RoleBinding{
@@ -626,5 +645,106 @@ func TestProcessServiceAccounts_ManagedByValueOverrideStamping(t *testing.T) {
 	}
 	if got := rb.Annotations[AnnotationCreatedBy]; got != "permission-binder-operator-e2e-7" {
 		t.Errorf("RB created-by annotation ignores MANAGED_BY_VALUE override: %q", got)
+	}
+}
+
+// ============================================================================
+// Stale-cache / transient-error paths (v1.8.0 status-poison fix)
+// ============================================================================
+
+// TestProcessServiceAccounts_SACreateAlreadyExistsTolerated verifies that a
+// Create racing a stale cached Get (informer lag: Get says NotFound, server
+// says AlreadyExists) does not abort the namespace - the SA exists, so
+// processing continues and the entry is reported.
+func TestProcessServiceAccounts_SACreateAlreadyExistsTolerated(t *testing.T) {
+	const ns = "team-race"
+	k8sClient := newSAFakeClientWithInterceptors(interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, ok := obj.(*corev1.ServiceAccount); ok {
+				return apierrors.NewAlreadyExists(
+					schema.GroupResource{Resource: "serviceaccounts"}, obj.GetName())
+			}
+			return c.Create(ctx, obj, opts...)
+		},
+	})
+
+	processed, err := ProcessServiceAccounts(context.Background(), k8sClient, ns,
+		map[string]string{"deploy": "edit"}, "", "my-binder", "my-namespace")
+	if err != nil {
+		t.Fatalf("AlreadyExists on SA Create must be tolerated, got error: %v", err)
+	}
+
+	fullSAName := GenerateServiceAccountName("", ns, "deploy")
+	want := ns + "/" + fullSAName
+	if len(processed) != 1 || processed[0] != want {
+		t.Errorf("expected processed=[%s], got %v", want, processed)
+	}
+
+	// The RoleBinding step must still have run
+	var rb rbacv1.RoleBinding
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "sa-" + ns + "-deploy", Namespace: ns}, &rb); err != nil {
+		t.Fatalf("RoleBinding not created after tolerated SA AlreadyExists: %v", err)
+	}
+}
+
+// TestProcessServiceAccounts_RBCreateAlreadyExistsTolerated verifies the same
+// stale-cache race on the ServiceAccount RoleBinding Create: the entry must
+// still be reported instead of aborting the whole namespace.
+func TestProcessServiceAccounts_RBCreateAlreadyExistsTolerated(t *testing.T) {
+	const ns = "team-race-rb"
+	k8sClient := newSAFakeClientWithInterceptors(interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, ok := obj.(*rbacv1.RoleBinding); ok {
+				return apierrors.NewAlreadyExists(
+					schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "rolebindings"}, obj.GetName())
+			}
+			return c.Create(ctx, obj, opts...)
+		},
+	})
+
+	processed, err := ProcessServiceAccounts(context.Background(), k8sClient, ns,
+		map[string]string{"deploy": "edit"}, "", "my-binder", "my-namespace")
+	if err != nil {
+		t.Fatalf("AlreadyExists on SA RoleBinding Create must be tolerated, got error: %v", err)
+	}
+
+	fullSAName := GenerateServiceAccountName("", ns, "deploy")
+	want := ns + "/" + fullSAName
+	if len(processed) != 1 || processed[0] != want {
+		t.Errorf("expected processed=[%s], got %v", want, processed)
+	}
+}
+
+// TestProcessServiceAccounts_TransientRBErrorReturned documents the failure
+// mode behind the v1.8.0 status-poison fix: a transient error on the SA
+// RoleBinding step happens AFTER the ServiceAccount was created, so the SA
+// exists but must NOT be reported as processed - and the error must surface
+// so the reconciler skips the ConfigMap-version stamp and retries.
+func TestProcessServiceAccounts_TransientRBErrorReturned(t *testing.T) {
+	const ns = "team-transient"
+	k8sClient := newSAFakeClientWithInterceptors(interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, ok := obj.(*rbacv1.RoleBinding); ok {
+				return apierrors.NewInternalError(fmt.Errorf("simulated transient apiserver failure"))
+			}
+			return c.Create(ctx, obj, opts...)
+		},
+	})
+
+	processed, err := ProcessServiceAccounts(context.Background(), k8sClient, ns,
+		map[string]string{"deploy": "edit"}, "", "my-binder", "my-namespace")
+	if err == nil {
+		t.Fatal("transient RoleBinding error must be returned, got nil")
+	}
+	if len(processed) != 0 {
+		t.Errorf("SA with failed RoleBinding must not be reported as processed, got %v", processed)
+	}
+
+	// The SA itself was created before the failing step - exactly the state
+	// that used to pass wait_for_sa in e2e while the status stayed empty.
+	fullSAName := GenerateServiceAccountName("", ns, "deploy")
+	var sa corev1.ServiceAccount
+	if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: fullSAName, Namespace: ns}, &sa); err != nil {
+		t.Fatalf("ServiceAccount should exist despite RoleBinding failure: %v", err)
 	}
 }

--- a/operator/internal/controller/status_poison_regression_test.go
+++ b/operator/internal/controller/status_poison_regression_test.go
@@ -1,0 +1,301 @@
+package controller
+
+// Manager-driven regression tests for the v1.8.0 status-poison fix.
+//
+// The shipped ginkgo suite only ever calls Reconcile() manually with a direct
+// client; these tests run the REAL manager path instead - cached client,
+// watch-driven reconciles and (on controller-runtime >= 0.23) the priority
+// queue - which is where the wedge lived. Derived from the envtest repro that
+// first proved the mechanism (parallel investigation session, 2026-08-24):
+//
+//	pass 1: full creation (ns+RB+SA+saRB) -> Status().Update FAILS transiently
+//	        (injected "etcdserver: request timed out", as seen on a loaded
+//	        rpi4-class apiserver)
+//	pass 2: retry a few ms later -> informer cache does not yet see the
+//	        namespace created in pass 1 (injected single stale NotFound) ->
+//	        ensureNamespace Create => AlreadyExists
+//
+// PRE-fix behavior (reproduced): the AlreadyExists dropped the whitelist
+// entry, ProcessedRoleBindings came out empty, the SA loop never ran, and the
+// EMPTY lists were stamped with LastProcessedConfigMapVersion - the skip
+// guard then wedged the CR permanently (only a ConfigMap RV bump healed it).
+//
+// POST-fix behavior (asserted here): the AlreadyExists falls through to the
+// ownership/update path via the uncached APIReader re-read, the pass
+// completes, and the status converges WITHOUT any ConfigMap bump. A
+// Processed=False/ProcessingIncomplete condition may appear transiently on an
+// incomplete pass but is timing-dependent, so it is not asserted.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	permissionv1 "github.com/permission-binder-operator/operator/api/v1"
+)
+
+const (
+	poisonOpNS   = "pbo-poison-regression"
+	poisonTestNS = "sa-test-34"
+	poisonSAName = poisonTestNS + "-sa-status-test"
+	poisonPBName = "test-sa-status-tracking"
+)
+
+// wedgeClient injects the reproduced failure sequence: one transient status
+// write failure for the test PB, then ONE stale NotFound for the namespace
+// created in pass 1 (models informer lag on a loaded cluster).
+type wedgeClient struct {
+	client.Client
+	statusFailed  atomic.Bool
+	staleNsServed atomic.Bool
+}
+
+func (w *wedgeClient) Status() client.SubResourceWriter {
+	return &wedgeStatusWriter{w.Client.Status(), w}
+}
+
+func (w *wedgeClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, isNS := obj.(*corev1.Namespace); isNS && key.Name == poisonTestNS &&
+		w.statusFailed.Load() && w.staleNsServed.CompareAndSwap(false, true) {
+		return apierrors.NewNotFound(schema.GroupResource{Resource: "namespaces"}, key.Name)
+	}
+	return w.Client.Get(ctx, key, obj, opts...)
+}
+
+type wedgeStatusWriter struct {
+	client.SubResourceWriter
+	p *wedgeClient
+}
+
+func (sw *wedgeStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	if pb, ok := obj.(*permissionv1.PermissionBinder); ok &&
+		pb.Name == poisonPBName &&
+		sw.p.statusFailed.CompareAndSwap(false, true) {
+		return fmt.Errorf("injected transient apiserver failure: etcdserver: request timed out")
+	}
+	return sw.SubResourceWriter.Update(ctx, obj, opts...)
+}
+
+type poisonEnv struct {
+	direct client.Client
+	ctx    context.Context
+}
+
+// startPoisonEnv boots a dedicated envtest apiserver plus a REAL manager and
+// registers the reconciler on it, optionally wrapping the manager client with
+// a failure-injection decorator. Cleanup is registered on t.
+func startPoisonEnv(t *testing.T, wrapClient func(client.Client) client.Client) *poisonEnv {
+	t.Helper()
+	ctrl.SetLogger(logzap.New(logzap.UseDevMode(false), logzap.WriteTo(os.Stdout)))
+
+	env := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
+			fmt.Sprintf("1.36.2-%s-%s", goruntime.GOOS, goruntime.GOARCH)),
+	}
+	cfg, err := env.Start()
+	if err != nil {
+		t.Fatalf("envtest start: %v", err)
+	}
+	t.Cleanup(func() { _ = env.Stop() })
+
+	sch := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(sch); err != nil {
+		t.Fatal(err)
+	}
+	if err := permissionv1.AddToScheme(sch); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:                 sch,
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+		LeaderElection:         false,
+		// Several tests in this file each build their own manager in the same
+		// process; skip the global controller-name uniqueness check.
+		Controller: config.Controller{SkipNameValidation: ptr.To(true)},
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{&corev1.Secret{}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("manager: %v", err)
+	}
+
+	mgrClient := mgr.GetClient()
+	if wrapClient != nil {
+		mgrClient = wrapClient(mgrClient)
+	}
+	rec := &PermissionBinderReconciler{
+		Client:    mgrClient,
+		Scheme:    mgr.GetScheme(),
+		APIReader: mgr.GetAPIReader(),
+		DebugMode: true,
+	}
+	if err := rec.SetupWithManager(mgr); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = mgr.Start(ctx) }()
+	if !mgr.GetCache().WaitForCacheSync(ctx) {
+		t.Fatal("cache never synced")
+	}
+
+	// direct (uncached) client for test assertions, like kubectl in the e2e
+	direct, err := client.New(cfg, client.Options{Scheme: sch})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := direct.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: poisonOpNS}}); err != nil {
+		t.Fatal(err)
+	}
+
+	return &poisonEnv{direct: direct, ctx: ctx}
+}
+
+// createTest34Fixtures mirrors example/tests/test-implementations/test-34-*.sh:
+// CM sa-test-config-34 first, then the PB with a ServiceAccount mapping.
+func createTest34Fixtures(t *testing.T, pe *poisonEnv) *corev1.ConfigMap {
+	t.Helper()
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "sa-test-config-34", Namespace: poisonOpNS},
+		Data: map[string]string{
+			"whitelist.txt": "    CN=COMPANY-K8S-" + poisonTestNS + "-developer,OU=Groups,DC=example,DC=com",
+		},
+	}
+	if err := pe.direct.Create(pe.ctx, cm); err != nil {
+		t.Fatal(err)
+	}
+	pb := &permissionv1.PermissionBinder{
+		ObjectMeta: metav1.ObjectMeta{Name: poisonPBName, Namespace: poisonOpNS},
+		Spec: permissionv1.PermissionBinderSpec{
+			ConfigMapName:         "sa-test-config-34",
+			ConfigMapNamespace:    poisonOpNS,
+			Prefixes:              []string{"COMPANY-K8S"},
+			RoleMapping:           map[string]string{"developer": "edit"},
+			ServiceAccountMapping: map[string]string{"status-test": "edit"},
+		},
+	}
+	if err := pe.direct.Create(pe.ctx, pb); err != nil {
+		t.Fatal(err)
+	}
+	return cm
+}
+
+func waitForPoison(t *testing.T, d time.Duration, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for %s", what)
+}
+
+// assertStatusConverges polls like the e2e's 60s status assertion and fails
+// the test when the entry never appears - the pre-fix wedge signature.
+func assertStatusConverges(t *testing.T, pe *poisonEnv) {
+	t.Helper()
+	expected := poisonTestNS + "/" + poisonSAName
+	var last permissionv1.PermissionBinder
+	found := false
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := pe.direct.Get(pe.ctx, types.NamespacedName{Name: poisonPBName, Namespace: poisonOpNS}, &last); err == nil {
+			for _, e := range last.Status.ProcessedServiceAccounts {
+				if e == expected {
+					found = true
+				}
+			}
+			if found {
+				break
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if !found {
+		t.Fatalf("WEDGED (regression): status.processedServiceAccounts missing %q; status: RBs=%v SAs=%v cmVer=%q conds=%+v",
+			expected, last.Status.ProcessedRoleBindings, last.Status.ProcessedServiceAccounts,
+			last.Status.LastProcessedConfigMapVersion, last.Status.Conditions)
+	}
+	if last.Status.LastProcessedConfigMapVersion == "" {
+		t.Error("converged status must carry the processed ConfigMap version")
+	}
+	processed := findCondition(last.Status.Conditions, "Processed")
+	if processed == nil || processed.Status != metav1.ConditionTrue {
+		t.Errorf("converged status must carry Processed=True, got: %+v", last.Status.Conditions)
+	}
+}
+
+// TestManagerDrivenSAStatusTracking is the e2e test 34 happy path against the
+// real manager (no failure injection) - guards the manager-driven code path
+// the ginkgo suite never exercises.
+func TestManagerDrivenSAStatusTracking(t *testing.T) {
+	if testing.Short() {
+		t.Skip("envtest-based, skipped in -short mode")
+	}
+	pe := startPoisonEnv(t, nil)
+	createTest34Fixtures(t, pe)
+
+	waitForPoison(t, 90*time.Second, "ServiceAccount "+poisonSAName, func() bool {
+		return pe.direct.Get(pe.ctx, types.NamespacedName{Name: poisonSAName, Namespace: poisonTestNS}, &corev1.ServiceAccount{}) == nil
+	})
+	assertStatusConverges(t, pe)
+}
+
+// TestStatusPoisonWedgeRegression injects the exact reproduced wedge sequence
+// (one transient status write failure + one stale namespace NotFound on the
+// retry) and asserts the FIXED behavior: the entry recovers via the uncached
+// AlreadyExists fall-through and the status converges WITHOUT any ConfigMap
+// bump. Pre-fix, this test wedges: empty lists, stamped guard, no self-heal.
+func TestStatusPoisonWedgeRegression(t *testing.T) {
+	if testing.Short() {
+		t.Skip("envtest-based, skipped in -short mode")
+	}
+	var wc *wedgeClient
+	pe := startPoisonEnv(t, func(c client.Client) client.Client {
+		wc = &wedgeClient{Client: c}
+		return wc
+	})
+	createTest34Fixtures(t, pe)
+
+	waitForPoison(t, 90*time.Second, "ServiceAccount "+poisonSAName, func() bool {
+		return pe.direct.Get(pe.ctx, types.NamespacedName{Name: poisonSAName, Namespace: poisonTestNS}, &corev1.ServiceAccount{}) == nil
+	})
+	assertStatusConverges(t, pe)
+
+	if !wc.statusFailed.Load() {
+		t.Error("injection never fired - the test exercised nothing")
+	}
+	if !wc.staleNsServed.Load() {
+		t.Log("note: stale-namespace injection did not fire (retry pass read a synced cache); status-failure half still validated")
+	}
+}


### PR DESCRIPTION
## Problem

E2E tests 34 (SA status tracking) and 21 (rapid-reconciliation stress) regressed on the cr-0.24.1/k8s-0.36 stack (`sha-9b18a5c`); operator source is unchanged vs v1.7.0 — the dependency stack widened race windows that fire **latent** operator bugs. The mechanism family was confirmed by an independent envtest repro (real manager + cached client + priority queue): one transient `Status().Update` failure → priority-queue retry ~5ms later → informers not yet caught up → stale reads wedge the CR permanently.

## Root cause — one poison, two entry paths

**The poison:** any pass that stamps `Status.LastProcessedConfigMapVersion` while its result is incomplete gets pinned forever by the skip guard — an unchanged ConfigMap fires no further events. Field unblock for a wedged CR: bump the ConfigMap's resourceVersion.

**Entry path A (SA loop):** `ProcessServiceAccounts` returns early when the SA-RoleBinding step fails; the SA (created just before) never reaches `processedSAs`; the caller logged it "non-fatal" and stamped anyway. This is why e2e `wait_for_sa` passes while the status assertion polls empty.

**Entry path B (entry-drop, empirically reproduced):** on a retry pass, `ensureNamespace`/`createRoleBinding` hit a stale cached `Get`=NotFound → `Create`=AlreadyExists → the caller's `continue` **drops the whitelist entry**; `ProcessedRoleBindings` comes out empty, the SA loop never runs, and EMPTY lists are stamped — no SA error at all, condition reads 'Successfully processed 0 role bindings and 0 service accounts'.

**Amplifier, not cause:** cr-0.23's default-on priority queue (5ms base retry) + client-go 0.36 informer pipeline + cr-0.21's removed client rate limiter make the transient-error and stale-cache windows far wider. The wedge could fire on any version under load.

## Fix

- **AlreadyExists = fall through, not drop:** `ensureNamespace` and `createRoleBinding` (and the SA path) re-read the object uncached via the new `APIReader` field (`mgr.GetAPIReader()`, falls back to the client when unset) and continue into the existing ownership/update path. The ownership gate still refuses foreign claims — covered by a dedicated test.
- **Incomplete-pass tracking across ALL three loops:** `ProcessConfigMapResult.IncompleteError` records the first entry-level failure from `ensureNamespace`, `createRoleBinding` or `ProcessServiceAccounts`. When set, the reconciler keeps the previous status lists, ConfigMap version and role-mapping hash (a partial pass must never shrink a previously-complete status), publishes a `Processed=False` condition (reason `ProcessingIncomplete`, error in message, current `observedGeneration`), and **requeues with backoff**.
- **Conflict-retried status write:** `Status().Update` wrapped in `retry.RetryOnConflict` with an uncached re-fetch — the failed status write is the pass-1 trigger of the wedge; resolving it in place avoids the vulnerable extra pass.
- **Client rate limiter restored** to the pre-cr-0.21 default (QPS 20/Burst 30), overridable via `CLIENT_QPS`/`CLIENT_BURST` (`-1` disables).
- Condition refresh on generation bump (`observedGeneration` joined the statusChanged gate — pre-existing gap).

## Verification

- 6 new unit tests: SA/SA-RB AlreadyExists tolerance, transient-RB-error propagation, stale-cache fall-through for Namespace and RoleBinding (shared fake store: intercepted Get = stale informer view, APIReader = server truth), foreign-claim refusal preserved.
- Full suite green against envtest **1.36.2** at every step.
- Pending: cluster validation of image `sha-86871f0` (dispatched) against tests 34/21/43 + full 62-test isolated suite on the merged head before v1.8.0.

## Release impact

v1.8.0 is **on hold** pending this fix + e2e rerun. Known-issue note for the field: a CR wedged by a pre-fix operator heals on any ConfigMap resourceVersion bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)