### PR TITLE
fix(networkpolicy): surface git failures in CR status and keep them retryable (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+- **NetworkPolicy git failures now surface in `status.networkPolicies`** (#54): the per-namespace error-status path was dead code with a pointer-vs-copy append bug that silently dropped `errorMessage` for first-time namespaces — a git/PR failure was logged and counted but never recorded on the CR (the v1.8.0 known issue, caught by e2e test 53). The event-driven batch loop now writes a `state: error` entry with the sanitized error message (bounded to 1 KiB), the event-driven filter re-processes entries in retryable states so a recorded failure keeps retrying (the periodic pass only considers `pr-merged` entries), and recovery is symmetric: a retry that creates a PR replaces the entry and clears the stale message, a retry with nothing left to do drops the stale entry. Covered by unit, batch-level, and manager-driven envtest regression tests mirroring e2e test 53.
+
+### 📊 Observability
+- `permission_binder_networkpolicy_git_operations_total` (clone/push by outcome) is now actually registered with the metrics registry — it was incremented but never exported, so it could not appear on `/metrics` (#54).
+
 ## [1.8.0] - 2026-08-24
 
 ### 🚀 Highlights

--- a/example/tests/scenarios/53-networkpolicy---git-operations-failures.md
+++ b/example/tests/scenarios/53-networkpolicy---git-operations-failures.md
@@ -93,7 +93,7 @@ curl -s http://localhost:8080/metrics | grep 'permission_binder_networkpolicy_gi
 - ✅ Operator does not crash on Git operation failures
 - ✅ Error messages include context (operation type, namespace)
 - ✅ Git operation errors are logged with audit trail
-- ✅ Metrics track Git operation failures (if implemented)
+- ✅ Metrics track Git operation failures (`permission_binder_networkpolicy_git_operations_total{operation="clone",status="error"}`)
 - ✅ Operator continues processing other namespaces (if applicable)
 - ✅ RBAC reconciliation continues to work (graceful degradation)
 

--- a/example/tests/test-implementations/test-53-networkpolicy---git-operations-failures.sh
+++ b/example/tests/test-implementations/test-53-networkpolicy---git-operations-failures.sh
@@ -131,8 +131,13 @@ if ! lsof -Pi :$METRICS_PORT -sTCP:LISTEN -t >/dev/null 2>&1; then
     sleep 3
 fi
 
-METRIC_VALUE=$(curl -s http://localhost:$METRICS_PORT/metrics 2>/dev/null | grep 'permission_binder_networkpolicy_pr_creation_errors_total' | grep 'namespace="'$TEST_NAMESPACE'"' | awk '{print $2}' | head -1 || echo "0")
-GIT_METRIC_VALUE=$(curl -s http://localhost:$METRICS_PORT/metrics 2>/dev/null | grep 'permission_binder_networkpolicy_git_operations_total' | grep 'status="error"' | awk '{print $2}' | head -1 || echo "0")
+# ${VAR:-0} defaults: when curl fails the pipeline still exits 0 (head's
+# status), so `|| echo 0` never fires and an empty value would spuriously pass
+# the != "0" check below
+METRIC_VALUE=$(curl -s http://localhost:$METRICS_PORT/metrics 2>/dev/null | grep 'permission_binder_networkpolicy_pr_creation_errors_total' | grep 'namespace="'$TEST_NAMESPACE'"' | awk '{print $2}' | head -1)
+METRIC_VALUE=${METRIC_VALUE:-0}
+GIT_METRIC_VALUE=$(curl -s http://localhost:$METRICS_PORT/metrics 2>/dev/null | grep 'permission_binder_networkpolicy_git_operations_total' | grep 'status="error"' | awk '{print $2}' | head -1)
+GIT_METRIC_VALUE=${GIT_METRIC_VALUE:-0}
 
 if [ "$METRIC_VALUE" != "0" ] || [ "$GIT_METRIC_VALUE" != "0" ]; then
     pass_test "Metrics captured Git failure (PR error: $METRIC_VALUE, git errors: $GIT_METRIC_VALUE)"

--- a/operator/internal/controller/metrics.go
+++ b/operator/internal/controller/metrics.go
@@ -149,6 +149,7 @@ func init() {
 		// NetworkPolicy metrics (from network_policy_helper.go)
 		networkpolicy.NetworkPolicyPRsCreatedTotal,
 		networkpolicy.NetworkPolicyPRCreationErrorsTotal,
+		networkpolicy.NetworkPolicyGitOperationsTotal,
 		networkpolicy.NetworkPolicyTemplateValidationErrorsTotal,
 		networkpolicy.NetworkPolicyMultipleCRsWarningTotal,
 	)

--- a/operator/internal/controller/networkpolicy/git_cli.go
+++ b/operator/internal/controller/networkpolicy/git_cli.go
@@ -68,12 +68,12 @@ func cloneGitRepo(ctx context.Context, repoURL string, credentials *gitCredentia
 	_, err = git.PlainCloneContext(ctx, tmpDir, false, cloneOptions)
 	if err != nil {
 		os.RemoveAll(tmpDir)
-		networkPolicyGitOperationsTotal.WithLabelValues("clone", "error").Inc()
+		NetworkPolicyGitOperationsTotal.WithLabelValues("clone", "error").Inc()
 		// Sanitize error to prevent token leakage
 		return "", fmt.Errorf("failed to clone repository: %w", sanitizeError(err, credentials))
 	}
 
-	networkPolicyGitOperationsTotal.WithLabelValues("clone", "success").Inc()
+	NetworkPolicyGitOperationsTotal.WithLabelValues("clone", "success").Inc()
 	return tmpDir, nil
 }
 
@@ -284,12 +284,12 @@ func gitCommitAndPush(ctx context.Context, repoDir string, branchName string, co
 
 	// Push
 	if err := repo.PushContext(ctx, pushOptions); err != nil {
-		networkPolicyGitOperationsTotal.WithLabelValues("push", "error").Inc()
+		NetworkPolicyGitOperationsTotal.WithLabelValues("push", "error").Inc()
 		// Sanitize error to prevent token leakage
 		return fmt.Errorf("failed to push: %w", sanitizeError(err, credentials))
 	}
 
-	networkPolicyGitOperationsTotal.WithLabelValues("push", "success").Inc()
+	NetworkPolicyGitOperationsTotal.WithLabelValues("push", "success").Inc()
 	logger.Info("Pushed changes to remote", "branch", branchName)
 	return nil
 }

--- a/operator/internal/controller/networkpolicy/git_security.go
+++ b/operator/internal/controller/networkpolicy/git_security.go
@@ -63,21 +63,17 @@ func sanitizeError(err error, credentials *gitCredentials) error {
 
 // sanitizeString removes sensitive information from strings (for logging).
 func sanitizeString(s string, credentials *gitCredentials) string {
-	if credentials == nil {
-		return s
-	}
-
 	result := s
 
 	// Remove token if present
-	if credentials.token != "" {
+	if credentials != nil && credentials.token != "" {
 		result = strings.ReplaceAll(result, credentials.token, "[REDACTED]")
 		// Also replace common token patterns
 		result = regexp.MustCompile(`(?i)(token|bearer|private-token|authorization)[\s:=]+[a-zA-Z0-9_-]{20,}`).ReplaceAllString(result, "$1 [REDACTED]")
 	}
 
 	// Remove username if present (might be sensitive)
-	if credentials.username != "" && credentials.username != "permission-binder-operator" {
+	if credentials != nil && credentials.username != "" && credentials.username != "permission-binder-operator" {
 		result = strings.ReplaceAll(result, credentials.username, "[REDACTED]")
 	}
 

--- a/operator/internal/controller/networkpolicy/network_policy_comparison_test.go
+++ b/operator/internal/controller/networkpolicy/network_policy_comparison_test.go
@@ -190,6 +190,6 @@ func TestHasNetworkPolicyStatus(t *testing.T) {
 		},
 	}
 
-	assert.True(t, hasNetworkPolicyStatus(permissionBinder, "my-namespace"))
-	assert.False(t, hasNetworkPolicyStatus(permissionBinder, "other-namespace"))
+	assert.NotNil(t, getNetworkPolicyStatus(permissionBinder, "my-namespace"))
+	assert.Nil(t, getNetworkPolicyStatus(permissionBinder, "other-namespace"))
 }

--- a/operator/internal/controller/networkpolicy/network_policy_constants.go
+++ b/operator/internal/controller/networkpolicy/network_policy_constants.go
@@ -41,6 +41,10 @@ const (
 	maxRetryAttempts = 3
 	retryBackoffBase = 5 * time.Second
 
+	// maxStatusErrorMessageLength bounds the error message stored in
+	// NetworkPolicyStatus.ErrorMessage (git errors can be long)
+	maxStatusErrorMessageLength = 1024
+
 	// Default values
 	defaultBatchSize              = 5
 	defaultSleepBetweenNamespaces = 3 * time.Second
@@ -107,7 +111,9 @@ var (
 		[]string{"cluster", "namespace", "variant", "error_type"},
 	)
 
-	networkPolicyGitOperationsTotal = prometheus.NewCounterVec(
+	// NetworkPolicyGitOperationsTotal counts Git operations (clone/push) by outcome.
+	// Labels: operation, status (success/error)
+	NetworkPolicyGitOperationsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "permission_binder_networkpolicy_git_operations_total",
 			Help: "Total number of Git operations for NetworkPolicy",

--- a/operator/internal/controller/networkpolicy/network_policy_status.go
+++ b/operator/internal/controller/networkpolicy/network_policy_status.go
@@ -41,7 +41,20 @@ func hasNetworkPolicyStatus(permissionBinder *permissionv1.PermissionBinder, nam
 	return getNetworkPolicyStatus(permissionBinder, namespace) != nil
 }
 
-// updateNetworkPolicyStatus updates or creates NetworkPolicy status for a namespace
+// isRetryableNetworkPolicyState reports whether a status entry in the given
+// state must be re-processed by the event-driven pass. Entries in state
+// "error" (a recorded failure) and entries with an empty state (defensive:
+// should not occur) would otherwise never be retried: the event-driven pass
+// skips namespaces that already have a status entry, and the periodic pass
+// only considers "pr-merged" entries.
+func isRetryableNetworkPolicyState(state string) bool {
+	return state == "error" || state == ""
+}
+
+// updateNetworkPolicyStatus updates or creates NetworkPolicy status for a namespace.
+// Uses retry logic with a fresh read to handle race conditions with concurrent
+// status updates. errorMessage is assigned unconditionally: pass "" to clear a
+// previously recorded error.
 func updateNetworkPolicyStatus(r ReconcilerInterface,
 	ctx context.Context,
 	permissionBinder *permissionv1.PermissionBinder,
@@ -51,44 +64,134 @@ func updateNetworkPolicyStatus(r ReconcilerInterface,
 ) error {
 	logger := log.FromContext(ctx)
 
-	// Find existing status or create new
-	status := getNetworkPolicyStatus(permissionBinder, namespace)
-	if status == nil {
-		// Create new status entry
-		status = &permissionv1.NetworkPolicyStatus{
-			Namespace: namespace,
-			State:     state,
+	// Bound the message stored in the CR (git errors can be long)
+	if len(errorMessage) > maxStatusErrorMessageLength {
+		errorMessage = errorMessage[:maxStatusErrorMessageLength]
+	}
+
+	// Retry logic to handle race conditions (max 3 attempts)
+	maxRetries := 3
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		// Get fresh copy of PermissionBinder to avoid stale data
+		key := client.ObjectKeyFromObject(permissionBinder)
+		var freshBinder permissionv1.PermissionBinder
+		if err := r.Get(ctx, key, &freshBinder); err != nil {
+			if attempt < maxRetries-1 {
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			return fmt.Errorf("failed to get fresh PermissionBinder: %w", err)
 		}
-		permissionBinder.Status.NetworkPolicies = append(permissionBinder.Status.NetworkPolicies, *status)
-	} else {
-		// Update existing status
+
+		status := getNetworkPolicyStatus(&freshBinder, namespace)
+		if status == nil {
+			// Create new status entry, then re-lookup: fields must be set on
+			// the slice element, not on a local copy the append left behind
+			// (a copy would silently drop State/ErrorMessage/CreatedAt).
+			freshBinder.Status.NetworkPolicies = append(freshBinder.Status.NetworkPolicies,
+				permissionv1.NetworkPolicyStatus{Namespace: namespace})
+			status = getNetworkPolicyStatus(&freshBinder, namespace)
+			if status == nil {
+				return fmt.Errorf("failed to get newly created status")
+			}
+		}
+
 		status.State = state
-	}
-
-	// Update fields
-	if errorMessage != "" {
 		status.ErrorMessage = errorMessage
-	}
 
-	if state == "pr-created" || state == "pr-pending" {
-		if status.CreatedAt == "" {
-			status.CreatedAt = time.Now().Format(time.RFC3339)
+		if state == "pr-created" || state == "pr-pending" {
+			if status.CreatedAt == "" {
+				status.CreatedAt = time.Now().Format(time.RFC3339)
+			}
 		}
-	}
 
-	// Update status in cluster
-	if err := r.Status().Update(ctx, permissionBinder); err != nil {
-		logger.Error(err, "Failed to update NetworkPolicy status",
+		// Update status in cluster
+		if err := r.Status().Update(ctx, &freshBinder); err != nil {
+			if attempt < maxRetries-1 {
+				logger.V(1).Info("Status update conflict, retrying", "attempt", attempt+1, "namespace", namespace)
+				time.Sleep(200 * time.Millisecond)
+				continue
+			}
+			logger.Error(err, "Failed to update NetworkPolicy status",
+				"namespace", namespace,
+				"state", state)
+			return fmt.Errorf("failed to update status: %w", err)
+		}
+
+		// Success - update the passed-in permissionBinder to reflect changes
+		*permissionBinder = freshBinder
+
+		logger.V(1).Info("Updated NetworkPolicy status",
 			"namespace", namespace,
 			"state", state)
-		return fmt.Errorf("failed to update status: %w", err)
+		return nil
 	}
 
-	logger.V(1).Info("Updated NetworkPolicy status",
-		"namespace", namespace,
-		"state", state)
+	return fmt.Errorf("failed to update status after %d attempts", maxRetries)
+}
 
-	return nil
+// clearNetworkPolicyStatusEntry removes the status entry for a namespace,
+// provided it is still in a retryable (error) state. Called when event-driven
+// processing completes without error but without creating a PR (nothing to
+// do): the recorded failure is resolved, and keeping the stale "error" entry
+// would misreport the namespace. Removing the entry restores the pre-failure
+// behavior (the namespace is re-evaluated on subsequent event-driven passes).
+func clearNetworkPolicyStatusEntry(r ReconcilerInterface,
+	ctx context.Context,
+	permissionBinder *permissionv1.PermissionBinder,
+	namespace string,
+) error {
+	logger := log.FromContext(ctx)
+
+	// Retry logic to handle race conditions (max 3 attempts)
+	maxRetries := 3
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		// Get fresh copy of PermissionBinder to avoid stale data
+		key := client.ObjectKeyFromObject(permissionBinder)
+		var freshBinder permissionv1.PermissionBinder
+		if err := r.Get(ctx, key, &freshBinder); err != nil {
+			if attempt < maxRetries-1 {
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			return fmt.Errorf("failed to get fresh PermissionBinder: %w", err)
+		}
+
+		// The fresh read makes this check meaningful: if a concurrent update
+		// already moved the entry to a non-retryable state (e.g. pr-created),
+		// leave it alone.
+		status := getNetworkPolicyStatus(&freshBinder, namespace)
+		if status == nil || !isRetryableNetworkPolicyState(status.State) {
+			*permissionBinder = freshBinder
+			return nil
+		}
+
+		kept := make([]permissionv1.NetworkPolicyStatus, 0, len(freshBinder.Status.NetworkPolicies))
+		for _, entry := range freshBinder.Status.NetworkPolicies {
+			if entry.Namespace != namespace {
+				kept = append(kept, entry)
+			}
+		}
+		freshBinder.Status.NetworkPolicies = kept
+
+		if err := r.Status().Update(ctx, &freshBinder); err != nil {
+			if attempt < maxRetries-1 {
+				logger.V(1).Info("Status update conflict, retrying", "attempt", attempt+1, "namespace", namespace)
+				time.Sleep(200 * time.Millisecond)
+				continue
+			}
+			logger.Error(err, "Failed to clear NetworkPolicy status entry", "namespace", namespace)
+			return fmt.Errorf("failed to update status: %w", err)
+		}
+
+		// Success - update the passed-in permissionBinder to reflect changes
+		*permissionBinder = freshBinder
+
+		logger.V(1).Info("Cleared stale NetworkPolicy error status entry", "namespace", namespace)
+		return nil
+	}
+
+	return fmt.Errorf("failed to update status after %d attempts", maxRetries)
 }
 
 // updateNetworkPolicyStatusWithPR updates NetworkPolicy status with PR information
@@ -138,6 +241,9 @@ func updateNetworkPolicyStatusWithPR(r ReconcilerInterface,
 		status.PRNumber = &prNumber
 		status.PRBranch = prBranch
 		status.PRURL = prURL
+		// PR creation succeeded - clear any error recorded by a previous
+		// failed attempt for this namespace
+		status.ErrorMessage = ""
 		if status.CreatedAt == "" {
 			status.CreatedAt = time.Now().Format(time.RFC3339)
 		}

--- a/operator/internal/controller/networkpolicy/network_policy_status.go
+++ b/operator/internal/controller/networkpolicy/network_policy_status.go
@@ -20,12 +20,23 @@ import (
 	"context"
 	"fmt"
 	"time"
+	"unicode/utf8"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	permissionv1 "github.com/permission-binder-operator/operator/api/v1"
 )
+
+// syncStatusFromFresh refreshes the caller's view of status (and the
+// resourceVersion the write bumped) WITHOUT replacing Spec/metadata: a
+// reconcile pass must keep operating on the spec snapshot it started from -
+// swapping the whole object mid-pass would let a concurrent spec edit tear
+// the batch loop (e.g. nil out Spec.NetworkPolicy underfoot).
+func syncStatusFromFresh(permissionBinder, freshBinder *permissionv1.PermissionBinder) {
+	permissionBinder.Status = freshBinder.Status
+	permissionBinder.ResourceVersion = freshBinder.ResourceVersion
+}
 
 func getNetworkPolicyStatus(permissionBinder *permissionv1.PermissionBinder, namespace string) *permissionv1.NetworkPolicyStatus {
 	for i := range permissionBinder.Status.NetworkPolicies {
@@ -34,11 +45,6 @@ func getNetworkPolicyStatus(permissionBinder *permissionv1.PermissionBinder, nam
 		}
 	}
 	return nil
-}
-
-// hasNetworkPolicyStatus checks if namespace has a status entry
-func hasNetworkPolicyStatus(permissionBinder *permissionv1.PermissionBinder, namespace string) bool {
-	return getNetworkPolicyStatus(permissionBinder, namespace) != nil
 }
 
 // isRetryableNetworkPolicyState reports whether a status entry in the given
@@ -64,9 +70,19 @@ func updateNetworkPolicyStatus(r ReconcilerInterface,
 ) error {
 	logger := log.FromContext(ctx)
 
-	// Bound the message stored in the CR (git errors can be long)
+	// Defense in depth: the CR status is readable by a wider audience than
+	// the logs. Callers pass sanitized errors, but e.g. detectGitProvider
+	// failures embed the raw repo URL, which may carry inline credentials.
+	errorMessage = sanitizeString(errorMessage, nil)
+
+	// Bound the message stored in the CR (git errors can be long), without
+	// splitting a multi-byte UTF-8 rune at the cut
 	if len(errorMessage) > maxStatusErrorMessageLength {
-		errorMessage = errorMessage[:maxStatusErrorMessageLength]
+		cut := maxStatusErrorMessageLength
+		for cut > 0 && !utf8.RuneStart(errorMessage[cut]) {
+			cut--
+		}
+		errorMessage = errorMessage[:cut]
 	}
 
 	// Retry logic to handle race conditions (max 3 attempts)
@@ -119,7 +135,7 @@ func updateNetworkPolicyStatus(r ReconcilerInterface,
 		}
 
 		// Success - update the passed-in permissionBinder to reflect changes
-		*permissionBinder = freshBinder
+		syncStatusFromFresh(permissionBinder, &freshBinder)
 
 		logger.V(1).Info("Updated NetworkPolicy status",
 			"namespace", namespace,
@@ -162,7 +178,7 @@ func clearNetworkPolicyStatusEntry(r ReconcilerInterface,
 		// leave it alone.
 		status := getNetworkPolicyStatus(&freshBinder, namespace)
 		if status == nil || !isRetryableNetworkPolicyState(status.State) {
-			*permissionBinder = freshBinder
+			syncStatusFromFresh(permissionBinder, &freshBinder)
 			return nil
 		}
 
@@ -185,7 +201,7 @@ func clearNetworkPolicyStatusEntry(r ReconcilerInterface,
 		}
 
 		// Success - update the passed-in permissionBinder to reflect changes
-		*permissionBinder = freshBinder
+		syncStatusFromFresh(permissionBinder, &freshBinder)
 
 		logger.V(1).Info("Cleared stale NetworkPolicy error status entry", "namespace", namespace)
 		return nil
@@ -260,7 +276,7 @@ func updateNetworkPolicyStatusWithPR(r ReconcilerInterface,
 		}
 
 		// Success - update the passed-in permissionBinder to reflect changes
-		*permissionBinder = freshBinder
+		syncStatusFromFresh(permissionBinder, &freshBinder)
 		return nil
 	}
 
@@ -359,7 +375,7 @@ func CleanupStatus(
 		}
 
 		// Success - update the passed-in permissionBinder to reflect changes
-		*permissionBinder = freshBinder
+		syncStatusFromFresh(permissionBinder, &freshBinder)
 		return nil
 	}
 

--- a/operator/internal/controller/networkpolicy/network_policy_status_test.go
+++ b/operator/internal/controller/networkpolicy/network_policy_status_test.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -155,6 +156,42 @@ func TestUpdateNetworkPolicyStatus_TruncatesLongMessage(t *testing.T) {
 	persisted := getPersistedBinder(t, r)
 	require.Len(t, persisted.Status.NetworkPolicies, 1)
 	assert.Len(t, persisted.Status.NetworkPolicies[0].ErrorMessage, maxStatusErrorMessageLength)
+}
+
+// TestUpdateNetworkPolicyStatus_SanitizesMessage: the CR status is readable
+// by a wider audience than the logs, so inline URL credentials (e.g. from a
+// detectGitProvider error embedding the raw repo URL) must never land there.
+func TestUpdateNetworkPolicyStatus_SanitizesMessage(t *testing.T) {
+	binder := newStatusTestBinder()
+	r := setupStatusFakeClient(binder)
+
+	err := updateNetworkPolicyStatus(r, context.Background(), binder, "some-ns", "error",
+		"cannot auto-detect git provider from URL: https://x:ghp_supersecret@git.corp/a/b.git")
+	require.NoError(t, err)
+
+	persisted := getPersistedBinder(t, r)
+	require.Len(t, persisted.Status.NetworkPolicies, 1)
+	msg := persisted.Status.NetworkPolicies[0].ErrorMessage
+	assert.NotContains(t, msg, "ghp_supersecret")
+	assert.Contains(t, msg, "://[REDACTED]:[REDACTED]@git.corp")
+}
+
+// TestUpdateNetworkPolicyStatus_TruncationIsRuneSafe: the 1KiB cap must not
+// split a multi-byte UTF-8 rune (which would render as U+FFFD in consumers).
+func TestUpdateNetworkPolicyStatus_TruncationIsRuneSafe(t *testing.T) {
+	binder := newStatusTestBinder()
+	r := setupStatusFakeClient(binder)
+
+	// 2-byte rune spanning the 1024-byte boundary
+	msg := strings.Repeat("x", maxStatusErrorMessageLength-1) + "żZZZZ"
+	err := updateNetworkPolicyStatus(r, context.Background(), binder, "some-ns", "error", msg)
+	require.NoError(t, err)
+
+	persisted := getPersistedBinder(t, r)
+	require.Len(t, persisted.Status.NetworkPolicies, 1)
+	stored := persisted.Status.NetworkPolicies[0].ErrorMessage
+	assert.True(t, utf8.ValidString(stored), "truncated message must remain valid UTF-8")
+	assert.Len(t, stored, maxStatusErrorMessageLength-1, "the split rune must be dropped, not cut")
 }
 
 func TestIsRetryableNetworkPolicyState(t *testing.T) {

--- a/operator/internal/controller/networkpolicy/network_policy_status_test.go
+++ b/operator/internal/controller/networkpolicy/network_policy_status_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networkpolicy
+
+// Regression tests for issue #54: NetworkPolicy git failures never reached CR
+// status. updateNetworkPolicyStatus was dead code with a pointer-vs-copy bug
+// that silently dropped ErrorMessage/CreatedAt for first-time namespaces, and
+// a naive call would have made failures permanent because the event-driven
+// filter skipped every namespace with a status entry.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	permissionv1 "github.com/permission-binder-operator/operator/api/v1"
+)
+
+// setupStatusFakeClient builds a fake client with the PermissionBinder status
+// subresource enabled, so Status().Update exercises the same path as a real
+// apiserver.
+func setupStatusFakeClient(objs ...client.Object) ReconcilerInterface {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = networkingv1.AddToScheme(scheme)
+	_ = permissionv1.AddToScheme(scheme)
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(&permissionv1.PermissionBinder{}).
+		Build()
+}
+
+func newStatusTestBinder(entries ...permissionv1.NetworkPolicyStatus) *permissionv1.PermissionBinder {
+	return &permissionv1.PermissionBinder{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-binder", Namespace: "default"},
+		Status: permissionv1.PermissionBinderStatus{
+			NetworkPolicies: entries,
+		},
+	}
+}
+
+func getPersistedBinder(t *testing.T, r ReconcilerInterface) *permissionv1.PermissionBinder {
+	t.Helper()
+	var binder permissionv1.PermissionBinder
+	require.NoError(t, r.Get(context.Background(),
+		types.NamespacedName{Name: "test-binder", Namespace: "default"}, &binder))
+	return &binder
+}
+
+// TestUpdateNetworkPolicyStatus_NewEntryPersistsFields is the direct
+// regression test for the pointer-vs-copy bug: the pre-fix code appended a
+// copy and then set ErrorMessage on a dangling local, so a NEW namespace
+// entry reached the cluster without the error message.
+func TestUpdateNetworkPolicyStatus_NewEntryPersistsFields(t *testing.T) {
+	binder := newStatusTestBinder()
+	r := setupStatusFakeClient(binder)
+
+	err := updateNetworkPolicyStatus(r, context.Background(), binder,
+		"test-git-failure", "error", "failed to clone repository: connection refused")
+	require.NoError(t, err)
+
+	persisted := getPersistedBinder(t, r)
+	require.Len(t, persisted.Status.NetworkPolicies, 1)
+	entry := persisted.Status.NetworkPolicies[0]
+	assert.Equal(t, "test-git-failure", entry.Namespace)
+	assert.Equal(t, "error", entry.State)
+	assert.Equal(t, "failed to clone repository: connection refused", entry.ErrorMessage,
+		"ErrorMessage must land on the appended slice element, not a local copy")
+
+	// The passed-in binder must reflect the persisted state too
+	inMemory := getNetworkPolicyStatus(binder, "test-git-failure")
+	require.NotNil(t, inMemory)
+	assert.Equal(t, "error", inMemory.State)
+	assert.Equal(t, "failed to clone repository: connection refused", inMemory.ErrorMessage)
+}
+
+// TestUpdateNetworkPolicyStatus_NewEntryStampsCreatedAt covers the second
+// field the pointer-vs-copy bug dropped for first-time namespaces.
+func TestUpdateNetworkPolicyStatus_NewEntryStampsCreatedAt(t *testing.T) {
+	binder := newStatusTestBinder()
+	r := setupStatusFakeClient(binder)
+
+	err := updateNetworkPolicyStatus(r, context.Background(), binder, "some-ns", "pr-pending", "")
+	require.NoError(t, err)
+
+	persisted := getPersistedBinder(t, r)
+	require.Len(t, persisted.Status.NetworkPolicies, 1)
+	assert.Equal(t, "pr-pending", persisted.Status.NetworkPolicies[0].State)
+	assert.NotEmpty(t, persisted.Status.NetworkPolicies[0].CreatedAt,
+		"CreatedAt must be stamped on the persisted entry for pr-pending")
+}
+
+// TestUpdateNetworkPolicyStatus_ExistingEntryTransitionClearsError asserts the
+// clear-on-success semantics: passing an empty errorMessage clears a
+// previously recorded error instead of leaving it stale.
+func TestUpdateNetworkPolicyStatus_ExistingEntryTransitionClearsError(t *testing.T) {
+	binder := newStatusTestBinder(
+		permissionv1.NetworkPolicyStatus{Namespace: "other-ns", State: "pr-merged"},
+		permissionv1.NetworkPolicyStatus{Namespace: "failed-ns", State: "error", ErrorMessage: "boom"},
+	)
+	r := setupStatusFakeClient(binder)
+
+	err := updateNetworkPolicyStatus(r, context.Background(), binder, "failed-ns", "pr-merged", "")
+	require.NoError(t, err)
+
+	persisted := getPersistedBinder(t, r)
+	require.Len(t, persisted.Status.NetworkPolicies, 2)
+	entry := getNetworkPolicyStatus(persisted, "failed-ns")
+	require.NotNil(t, entry)
+	assert.Equal(t, "pr-merged", entry.State)
+	assert.Empty(t, entry.ErrorMessage, "transition to success must clear the stale error message")
+
+	// Sibling entry untouched
+	other := getNetworkPolicyStatus(persisted, "other-ns")
+	require.NotNil(t, other)
+	assert.Equal(t, "pr-merged", other.State)
+}
+
+// TestUpdateNetworkPolicyStatus_TruncatesLongMessage bounds what a verbose git
+// error can push into the CR.
+func TestUpdateNetworkPolicyStatus_TruncatesLongMessage(t *testing.T) {
+	binder := newStatusTestBinder()
+	r := setupStatusFakeClient(binder)
+
+	err := updateNetworkPolicyStatus(r, context.Background(), binder,
+		"some-ns", "error", strings.Repeat("x", 5000))
+	require.NoError(t, err)
+
+	persisted := getPersistedBinder(t, r)
+	require.Len(t, persisted.Status.NetworkPolicies, 1)
+	assert.Len(t, persisted.Status.NetworkPolicies[0].ErrorMessage, maxStatusErrorMessageLength)
+}
+
+func TestIsRetryableNetworkPolicyState(t *testing.T) {
+	tests := []struct {
+		state     string
+		retryable bool
+	}{
+		{"error", true},
+		{"", true}, // defensive: unknown/empty entries must not wedge
+		{"pr-created", false},
+		{"pr-pending", false},
+		{"pr-merged", false},
+		{"pr-conflict", false},
+		{"pr-stale", false},
+		{"pr-removal", false},
+		{"removed", false},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.retryable, isRetryableNetworkPolicyState(tt.state), "state %q", tt.state)
+	}
+}
+
+// TestClearNetworkPolicyStatusEntry_RemovesOnlyRetryableEntry asserts the
+// recovery path drops the stale error entry and nothing else.
+func TestClearNetworkPolicyStatusEntry_RemovesOnlyRetryableEntry(t *testing.T) {
+	binder := newStatusTestBinder(
+		permissionv1.NetworkPolicyStatus{Namespace: "other-ns", State: "pr-merged"},
+		permissionv1.NetworkPolicyStatus{Namespace: "failed-ns", State: "error", ErrorMessage: "boom"},
+	)
+	r := setupStatusFakeClient(binder)
+
+	err := clearNetworkPolicyStatusEntry(r, context.Background(), binder, "failed-ns")
+	require.NoError(t, err)
+
+	persisted := getPersistedBinder(t, r)
+	require.Len(t, persisted.Status.NetworkPolicies, 1)
+	assert.Equal(t, "other-ns", persisted.Status.NetworkPolicies[0].Namespace)
+	assert.Nil(t, getNetworkPolicyStatus(binder, "failed-ns"), "in-memory binder must reflect the removal")
+}
+
+// TestClearNetworkPolicyStatusEntry_LeavesNonRetryableEntry guards against
+// clobbering a concurrent success write: only entries still in a retryable
+// state are removed.
+func TestClearNetworkPolicyStatusEntry_LeavesNonRetryableEntry(t *testing.T) {
+	binder := newStatusTestBinder(
+		permissionv1.NetworkPolicyStatus{Namespace: "some-ns", State: "pr-created"},
+	)
+	r := setupStatusFakeClient(binder)
+
+	err := clearNetworkPolicyStatusEntry(r, context.Background(), binder, "some-ns")
+	require.NoError(t, err)
+
+	persisted := getPersistedBinder(t, r)
+	require.Len(t, persisted.Status.NetworkPolicies, 1)
+	assert.Equal(t, "pr-created", persisted.Status.NetworkPolicies[0].State)
+}
+
+func TestClearNetworkPolicyStatusEntry_MissingEntryIsNoop(t *testing.T) {
+	binder := newStatusTestBinder()
+	r := setupStatusFakeClient(binder)
+
+	assert.NoError(t, clearNetworkPolicyStatusEntry(r, context.Background(), binder, "absent-ns"))
+}
+
+// TestUpdateNetworkPolicyStatusWithPR_ClearsErrorMessage asserts the success
+// transition for a namespace that previously failed: the PR fields replace the
+// error entry and the stale message is cleared.
+func TestUpdateNetworkPolicyStatusWithPR_ClearsErrorMessage(t *testing.T) {
+	binder := newStatusTestBinder(
+		permissionv1.NetworkPolicyStatus{Namespace: "failed-ns", State: "error", ErrorMessage: "boom"},
+	)
+	r := setupStatusFakeClient(binder)
+
+	err := updateNetworkPolicyStatusWithPR(r, context.Background(), binder,
+		"failed-ns", 42, "networkpolicy/DEV-cluster-failed-ns", "https://example.com/pr/42", "pr-created")
+	require.NoError(t, err)
+
+	persisted := getPersistedBinder(t, r)
+	entry := getNetworkPolicyStatus(persisted, "failed-ns")
+	require.NotNil(t, entry)
+	assert.Equal(t, "pr-created", entry.State)
+	assert.Empty(t, entry.ErrorMessage, "successful PR creation must clear the previous error")
+	require.NotNil(t, entry.PRNumber)
+	assert.Equal(t, 42, *entry.PRNumber)
+	assert.NotEmpty(t, entry.CreatedAt)
+}

--- a/operator/internal/controller/networkpolicy/reconciliation_batch.go
+++ b/operator/internal/controller/networkpolicy/reconciliation_batch.go
@@ -25,6 +25,43 @@ import (
 	permissionv1 "github.com/permission-binder-operator/operator/api/v1"
 )
 
+// processNamespaceFn indirects the per-namespace processing step so tests can
+// stub out the Git/PR workflow. Production always uses ProcessNetworkPolicyForNamespace.
+var processNamespaceFn = ProcessNetworkPolicyForNamespace
+
+// selectNamespacesForEventDrivenProcessing returns the subset of namespaces the
+// event-driven pass must process: namespaces without a status entry (never
+// processed) and namespaces whose entry is in a retryable state ("error").
+// Entries in any other state (pr-created, pr-pending, pr-merged, ...) are
+// already tracked and skipped.
+func selectNamespacesForEventDrivenProcessing(
+	ctx context.Context,
+	permissionBinder *permissionv1.PermissionBinder,
+	namespaces []string,
+) []string {
+	logger := log.FromContext(ctx)
+
+	var namespaceList []string
+	for _, ns := range namespaces {
+		status := getNetworkPolicyStatus(permissionBinder, ns)
+		switch {
+		case status == nil:
+			namespaceList = append(namespaceList, ns)
+		case isRetryableNetworkPolicyState(status.State):
+			logger.V(1).Info("Re-processing namespace - previous attempt failed",
+				"namespace", ns,
+				"state", status.State,
+				"reason", "retryable_status_entry")
+			namespaceList = append(namespaceList, ns)
+		default:
+			logger.V(1).Info("Skipping namespace - already processed",
+				"namespace", ns,
+				"reason", "has_status_entry")
+		}
+	}
+	return namespaceList
+}
+
 // ProcessNetworkPoliciesForNamespaces processes NetworkPolicy management for multiple namespaces in batches.
 //
 // This function processes namespaces in configurable batches to avoid overwhelming
@@ -82,17 +119,11 @@ func ProcessNetworkPoliciesForNamespaces(
 		}
 	}
 
-	// Filter namespaces - skip those that already have status (optimization)
-	var namespaceList []string
-	for _, ns := range namespaces {
-		if !hasNetworkPolicyStatus(permissionBinder, ns) {
-			namespaceList = append(namespaceList, ns)
-		} else {
-			logger.V(1).Info("Skipping namespace - already processed",
-				"namespace", ns,
-				"reason", "has_status_entry")
-		}
-	}
+	// Filter namespaces - skip those that already have status (optimization),
+	// EXCEPT entries in a retryable state ("error"): the periodic pass only
+	// considers "pr-merged" entries, so the event-driven pass is the only
+	// retry path for previously failed namespaces.
+	namespaceList := selectNamespacesForEventDrivenProcessing(ctx, permissionBinder, namespaces)
 
 	// Batch processing
 	batches := chunkNamespaces(namespaceList, batchSize)
@@ -104,9 +135,23 @@ func ProcessNetworkPoliciesForNamespaces(
 			"batchSize", len(batch))
 
 		for _, namespace := range batch {
-			if err := ProcessNetworkPolicyForNamespace(ctx, r, permissionBinder, namespace); err != nil {
+			if err := processNamespaceFn(ctx, r, permissionBinder, namespace); err != nil {
 				logger.Error(err, "Failed to process NetworkPolicy", "namespace", namespace)
+				// Record the failure on the CR so it is visible in
+				// status.networkPolicies; the event-driven filter above
+				// re-processes entries in state "error" on later passes.
+				if statusErr := updateNetworkPolicyStatus(r, ctx, permissionBinder, namespace, "error", err.Error()); statusErr != nil {
+					logger.Error(statusErr, "Failed to record NetworkPolicy failure in status", "namespace", namespace)
+				}
 				// Continue with other namespaces
+			} else if status := getNetworkPolicyStatus(permissionBinder, namespace); status != nil && isRetryableNetworkPolicyState(status.State) {
+				// The retry succeeded without creating a PR (nothing left to
+				// do): drop the stale error entry so status no longer
+				// misreports the namespace. A retry that created a PR already
+				// replaced the entry via updateNetworkPolicyStatusWithPR.
+				if statusErr := clearNetworkPolicyStatusEntry(r, ctx, permissionBinder, namespace); statusErr != nil {
+					logger.Error(statusErr, "Failed to clear stale NetworkPolicy error status", "namespace", namespace)
+				}
 			}
 
 			// Sleep between namespaces (rate limiting for Git API)

--- a/operator/internal/controller/networkpolicy/reconciliation_batch_test.go
+++ b/operator/internal/controller/networkpolicy/reconciliation_batch_test.go
@@ -24,6 +24,7 @@ package networkpolicy
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -203,4 +204,6 @@ func TestProcessNetworkPoliciesForNamespaces_CloneFailureEndToEnd(t *testing.T) 
 	require.NotNil(t, entry, "clone failure must be recorded in status.networkPolicies")
 	assert.Equal(t, "error", entry.State)
 	assert.Contains(t, entry.ErrorMessage, "failed to clone repository")
+	assert.Equal(t, 1, strings.Count(entry.ErrorMessage, "failed to clone repository"),
+		"the clone error must not be double-prefixed by re-wrapping")
 }

--- a/operator/internal/controller/networkpolicy/reconciliation_batch_test.go
+++ b/operator/internal/controller/networkpolicy/reconciliation_batch_test.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networkpolicy
+
+// Regression tests for issue #54: the event-driven batch loop must record
+// per-namespace git failures in status.networkPolicies, keep failed
+// namespaces retryable (the periodic pass only considers "pr-merged"
+// entries), and clean up after a successful retry.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	permissionv1 "github.com/permission-binder-operator/operator/api/v1"
+)
+
+// fastBatchSpec keeps the loop's rate-limiting sleeps out of unit tests.
+func fastBatchSpec() *permissionv1.NetworkPolicySpec {
+	return &permissionv1.NetworkPolicySpec{
+		Enabled: true,
+		BatchProcessing: &permissionv1.BatchProcessingSpec{
+			BatchSize:              5,
+			SleepBetweenNamespaces: "1ms",
+			SleepBetweenBatches:    "1ms",
+		},
+	}
+}
+
+// stubProcessNamespace swaps the per-namespace processing step for the test's
+// duration and restores the real implementation afterwards.
+func stubProcessNamespace(t *testing.T, fn func(ctx context.Context, r ReconcilerInterface, permissionBinder *permissionv1.PermissionBinder, namespace string) error) {
+	t.Helper()
+	orig := processNamespaceFn
+	processNamespaceFn = fn
+	t.Cleanup(func() { processNamespaceFn = orig })
+}
+
+func TestSelectNamespacesForEventDrivenProcessing(t *testing.T) {
+	binder := newStatusTestBinder(
+		permissionv1.NetworkPolicyStatus{Namespace: "ns-error", State: "error", ErrorMessage: "boom"},
+		permissionv1.NetworkPolicyStatus{Namespace: "ns-merged", State: "pr-merged"},
+		permissionv1.NetworkPolicyStatus{Namespace: "ns-pending", State: "pr-pending"},
+		permissionv1.NetworkPolicyStatus{Namespace: "ns-empty-state", State: ""},
+	)
+
+	selected := selectNamespacesForEventDrivenProcessing(context.Background(), binder,
+		[]string{"ns-new", "ns-error", "ns-merged", "ns-pending", "ns-empty-state"})
+
+	// ns-new: never processed; ns-error/ns-empty-state: retryable - the
+	// pre-fix filter skipped ANY namespace with a status entry, which would
+	// have made a recorded failure permanent.
+	assert.Equal(t, []string{"ns-new", "ns-error", "ns-empty-state"}, selected)
+}
+
+// TestProcessNetworkPoliciesForNamespaces_RecordsFailureInStatus asserts
+// defect 1 end-to-end at the batch level: a per-namespace failure lands in
+// status.networkPolicies as an "error" entry instead of being dropped.
+func TestProcessNetworkPoliciesForNamespaces_RecordsFailureInStatus(t *testing.T) {
+	binder := newStatusTestBinder(
+		permissionv1.NetworkPolicyStatus{Namespace: "ns-merged", State: "pr-merged"},
+	)
+	binder.Spec.NetworkPolicy = fastBatchSpec()
+	r := setupStatusFakeClient(binder)
+
+	var processed []string
+	stubProcessNamespace(t, func(_ context.Context, _ ReconcilerInterface, _ *permissionv1.PermissionBinder, namespace string) error {
+		processed = append(processed, namespace)
+		return errors.New("failed to clone repository: connection refused")
+	})
+
+	err := ProcessNetworkPoliciesForNamespaces(context.Background(), r, binder,
+		[]string{"failing-ns", "ns-merged"})
+	require.NoError(t, err, "per-namespace failures must not abort the batch")
+
+	assert.Equal(t, []string{"failing-ns"}, processed, "pr-merged namespace must be skipped")
+
+	persisted := getPersistedBinder(t, r)
+	entry := getNetworkPolicyStatus(persisted, "failing-ns")
+	require.NotNil(t, entry, "failure must be recorded in status.networkPolicies")
+	assert.Equal(t, "error", entry.State)
+	assert.Equal(t, "failed to clone repository: connection refused", entry.ErrorMessage)
+}
+
+// TestProcessNetworkPoliciesForNamespaces_RetriesAndDropsStaleEntryOnRecovery
+// covers defect 3 plus the recovery path: a recorded failure is re-processed
+// on the next pass, and a successful retry with nothing left to do removes
+// the stale error entry.
+func TestProcessNetworkPoliciesForNamespaces_RetriesAndDropsStaleEntryOnRecovery(t *testing.T) {
+	binder := newStatusTestBinder()
+	binder.Spec.NetworkPolicy = fastBatchSpec()
+	r := setupStatusFakeClient(binder)
+
+	calls := 0
+	stubProcessNamespace(t, func(_ context.Context, _ ReconcilerInterface, _ *permissionv1.PermissionBinder, _ string) error {
+		calls++
+		if calls == 1 {
+			return errors.New("transient git outage")
+		}
+		return nil // recovered, nothing left to do (no PR created)
+	})
+
+	// Pass 1: failure recorded
+	require.NoError(t, ProcessNetworkPoliciesForNamespaces(context.Background(), r, binder, []string{"flaky-ns"}))
+	entry := getNetworkPolicyStatus(getPersistedBinder(t, r), "flaky-ns")
+	require.NotNil(t, entry)
+	require.Equal(t, "error", entry.State)
+
+	// Pass 2: the error entry must NOT block re-processing (pre-fix filter
+	// semantics would have skipped it forever), and the successful no-op
+	// retry must drop the stale entry.
+	require.NoError(t, ProcessNetworkPoliciesForNamespaces(context.Background(), r, binder, []string{"flaky-ns"}))
+	assert.Equal(t, 2, calls, "namespace with an error entry must be retried")
+	assert.Nil(t, getNetworkPolicyStatus(getPersistedBinder(t, r), "flaky-ns"),
+		"stale error entry must be removed after a successful no-op retry")
+}
+
+// TestProcessNetworkPoliciesForNamespaces_RetryThatCreatesPRReplacesEntry
+// asserts the other recovery shape: a retry that creates a PR replaces the
+// error entry (via updateNetworkPolicyStatusWithPR) and the batch loop leaves
+// the new entry alone.
+func TestProcessNetworkPoliciesForNamespaces_RetryThatCreatesPRReplacesEntry(t *testing.T) {
+	binder := newStatusTestBinder(
+		permissionv1.NetworkPolicyStatus{Namespace: "flaky-ns", State: "error", ErrorMessage: "previous failure"},
+	)
+	binder.Spec.NetworkPolicy = fastBatchSpec()
+	r := setupStatusFakeClient(binder)
+
+	stubProcessNamespace(t, func(ctx context.Context, r ReconcilerInterface, pb *permissionv1.PermissionBinder, namespace string) error {
+		// Mirror what ProcessNetworkPolicyForNamespace does on success
+		return updateNetworkPolicyStatusWithPR(r, ctx, pb, namespace, 7, "networkpolicy/DEV-cluster-"+namespace, "https://example.com/pr/7", "pr-created")
+	})
+
+	require.NoError(t, ProcessNetworkPoliciesForNamespaces(context.Background(), r, binder, []string{"flaky-ns"}))
+
+	entry := getNetworkPolicyStatus(getPersistedBinder(t, r), "flaky-ns")
+	require.NotNil(t, entry, "the pr-created entry must survive the batch loop's cleanup step")
+	assert.Equal(t, "pr-created", entry.State)
+	assert.Empty(t, entry.ErrorMessage)
+	require.NotNil(t, entry.PRNumber)
+	assert.Equal(t, 7, *entry.PRNumber)
+}
+
+// TestProcessNetworkPoliciesForNamespaces_CloneFailureEndToEnd exercises the
+// REAL ProcessNetworkPolicyForNamespace (no stub) against an unreachable git
+// remote - the exact e2e test 53 scenario (invalid credentials/unreachable
+// repo) - and asserts the failure surfaces in status. Hermetic: the clone
+// dials 127.0.0.1:1 in-process and fails instantly with connection refused.
+func TestProcessNetworkPoliciesForNamespaces_CloneFailureEndToEnd(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "git-creds", Namespace: "default"},
+		Data: map[string][]byte{
+			"token":    []byte("invalid-token"),
+			"username": []byte("invalid-user"),
+			"email":    []byte("invalid@example.com"),
+		},
+	}
+	binder := newStatusTestBinder()
+	binder.Spec.NetworkPolicy = &permissionv1.NetworkPolicySpec{
+		Enabled:     true,
+		TemplateDir: "networkpolicies/templates",
+		GitRepository: &permissionv1.GitRepositorySpec{
+			Provider:    "github",
+			URL:         "http://127.0.0.1:1/tests/does-not-exist.git",
+			BaseBranch:  "main",
+			ClusterName: "DEV-cluster",
+			CredentialsSecretRef: &permissionv1.LdapSecretReference{
+				Name:      "git-creds",
+				Namespace: "default",
+			},
+		},
+		BatchProcessing: &permissionv1.BatchProcessingSpec{
+			BatchSize:              5,
+			SleepBetweenNamespaces: "1ms",
+			SleepBetweenBatches:    "1ms",
+		},
+	}
+	r := setupStatusFakeClient(binder, secret)
+
+	require.NoError(t, ProcessNetworkPoliciesForNamespaces(context.Background(), r, binder, []string{"test-git-failure"}))
+
+	persisted := getPersistedBinder(t, r)
+	entry := getNetworkPolicyStatus(persisted, "test-git-failure")
+	require.NotNil(t, entry, "clone failure must be recorded in status.networkPolicies")
+	assert.Equal(t, "error", entry.State)
+	assert.Contains(t, entry.ErrorMessage, "failed to clone repository")
+}

--- a/operator/internal/controller/networkpolicy/reconciliation_single.go
+++ b/operator/internal/controller/networkpolicy/reconciliation_single.go
@@ -95,7 +95,8 @@ func ProcessNetworkPolicyForNamespace(
 	// Clone repo (always fresh clone for self-contained test isolation)
 	tmpDir, err := cloneGitRepo(ctx, gitRepo.URL, credentials, tlsVerify)
 	if err != nil {
-		return fmt.Errorf("failed to clone repository: %w", err)
+		// cloneGitRepo already prefixes and sanitizes its errors
+		return err
 	}
 	defer os.RemoveAll(tmpDir)
 
@@ -311,8 +312,14 @@ func ProcessNetworkPolicyForNamespace(
 	apiBaseURL := getAPIBaseURL(provider, gitRepo.APIBaseURL, gitRepo.URL)
 	existingPR, err := getPRByBranch(ctx, provider, apiBaseURL, gitRepo.URL, branchName, credentials, tlsVerify)
 	if err == nil && existingPR != nil && existingPR.State == "OPEN" {
-		// PR already exists and is open - skip
+		// PR already exists and is open - record it and skip. Without a
+		// status entry the namespace would be re-selected (and re-cloned)
+		// on every event-driven pass, and a previously recorded "error"
+		// entry would be dropped instead of transitioning to the PR state.
 		logger.V(1).Info("PR already exists and is open for namespace", "namespace", namespace, "prNumber", existingPR.Number)
+		if err := updateNetworkPolicyStatusWithPR(r, ctx, permissionBinder, namespace, existingPR.Number, branchName, existingPR.URL, "pr-pending"); err != nil {
+			logger.Error(err, "Failed to record existing PR in status", "namespace", namespace)
+		}
 		return nil
 	}
 

--- a/operator/internal/controller/np_error_status_regression_test.go
+++ b/operator/internal/controller/np_error_status_regression_test.go
@@ -1,0 +1,172 @@
+package controller
+
+// Manager-driven regression test for issue #54: NetworkPolicy git failures
+// never reached CR status (e2e test 53).
+//
+// Mirrors example/tests/test-implementations/test-53-networkpolicy---git-
+// operations-failures.sh against a real manager: a PermissionBinder with
+// NetworkPolicy enabled points at an unreachable git remote (the e2e uses
+// invalid credentials; here the clone dials 127.0.0.1:1 in-process and fails
+// instantly, keeping the test hermetic). Three defects cooperated pre-fix:
+//
+//  1. updateNetworkPolicyStatus was dead code - the batch loop logged the
+//     per-namespace failure and dropped it, so status.networkPolicies never
+//     carried the error (phase 1 asserts the entry appears).
+//  2. A pointer-vs-copy append bug would have silently dropped ErrorMessage
+//     for first-time namespaces even if the function had been called
+//     (phase 1's ErrorMessage assertion covers the persisted value).
+//  3. The event-driven filter skipped every namespace with a status entry
+//     and the periodic pass only considers "pr-merged" entries - so a naive
+//     error entry would have made the failure permanent. Phase 2 bumps the
+//     ConfigMap and proves the failed namespace is re-processed (clone
+//     attempt counter grows) despite its existing error entry.
+//
+// Retry cadence note: the main reconcile skip guard (unchanged ConfigMap
+// version + role mapping) gates ALL NetworkPolicy processing, so retries
+// happen on the passes that run at all - same cadence as the pre-fix
+// behavior for entry-less failed namespaces.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	permissionv1 "github.com/permission-binder-operator/operator/api/v1"
+	"github.com/permission-binder-operator/operator/internal/controller/networkpolicy"
+)
+
+const (
+	npErrPBName   = "test-pb-networkpolicy-git-failure"
+	npErrCMName   = "np-git-failure-config"
+	npErrSecret   = "github-gitops-credentials-invalid"
+	npErrTargetNS = "test-git-failure"
+)
+
+// createNPGitFailureFixtures mirrors the e2e test 53 setup: invalid git
+// credentials Secret, a whitelist ConfigMap, and a PermissionBinder with
+// NetworkPolicy enabled against an unreachable repository.
+func createNPGitFailureFixtures(t *testing.T, pe *poisonEnv) {
+	t.Helper()
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: npErrSecret, Namespace: poisonOpNS},
+		StringData: map[string]string{
+			"token":    "invalid-token",
+			"username": "invalid-user",
+			"email":    "invalid@example.com",
+		},
+	}
+	if err := pe.direct.Create(pe.ctx, secret); err != nil {
+		t.Fatal(err)
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: npErrCMName, Namespace: poisonOpNS},
+		Data: map[string]string{
+			"whitelist.txt": "CN=COMPANY-K8S-" + npErrTargetNS + "-engineer,OU=Openshift,DC=example,DC=com",
+		},
+	}
+	if err := pe.direct.Create(pe.ctx, cm); err != nil {
+		t.Fatal(err)
+	}
+
+	pb := &permissionv1.PermissionBinder{
+		ObjectMeta: metav1.ObjectMeta{Name: npErrPBName, Namespace: poisonOpNS},
+		Spec: permissionv1.PermissionBinderSpec{
+			ConfigMapName:      npErrCMName,
+			ConfigMapNamespace: poisonOpNS,
+			Prefixes:           []string{"COMPANY-K8S"},
+			RoleMapping:        map[string]string{"engineer": "edit", "viewer": "view"},
+			NetworkPolicy: &permissionv1.NetworkPolicySpec{
+				Enabled:        true,
+				TemplateDir:    "networkpolicies/templates",
+				BackupExisting: true,
+				GitRepository: &permissionv1.GitRepositorySpec{
+					Provider:    "github",
+					URL:         "http://127.0.0.1:1/tests/does-not-exist.git",
+					BaseBranch:  "main",
+					ClusterName: "DEV-cluster",
+					CredentialsSecretRef: &permissionv1.LdapSecretReference{
+						Name:      npErrSecret,
+						Namespace: poisonOpNS,
+					},
+				},
+			},
+		},
+	}
+	if err := pe.direct.Create(pe.ctx, pb); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func getNPErrorEntry(t *testing.T, pe *poisonEnv) *permissionv1.NetworkPolicyStatus {
+	t.Helper()
+	var pb permissionv1.PermissionBinder
+	if err := pe.direct.Get(pe.ctx,
+		types.NamespacedName{Name: npErrPBName, Namespace: poisonOpNS}, &pb); err != nil {
+		return nil
+	}
+	for i := range pb.Status.NetworkPolicies {
+		if pb.Status.NetworkPolicies[i].Namespace == npErrTargetNS {
+			return &pb.Status.NetworkPolicies[i]
+		}
+	}
+	return nil
+}
+
+// TestNetworkPolicyGitFailureSurfacesInStatus is the in-repo acceptance test
+// for issue #54 (e2e test 53 is the live acceptance test).
+func TestNetworkPolicyGitFailureSurfacesInStatus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("envtest-based, skipped in -short mode")
+	}
+	pe := startPoisonEnv(t, nil)
+	createNPGitFailureFixtures(t, pe)
+
+	// Phase 1 (defects 1+2): the git failure must surface as an "error"
+	// entry carrying the sanitized error message - the e2e test 53
+	// assertion that failed pre-fix.
+	waitForPoison(t, 90*time.Second, "error entry in status.networkPolicies", func() bool {
+		e := getNPErrorEntry(t, pe)
+		return e != nil && e.State == "error" && e.ErrorMessage != ""
+	})
+	entry := getNPErrorEntry(t, pe)
+	if !strings.Contains(entry.ErrorMessage, "failed to clone repository") {
+		t.Errorf("errorMessage should carry the clone failure, got: %q", entry.ErrorMessage)
+	}
+
+	// Phase 2 (defect 3): the recorded error entry must not block retries.
+	// Bump the ConfigMap (new role for the same namespace) so a reconcile
+	// passes the skip guard, and prove another clone attempt happens for the
+	// namespace despite its existing status entry.
+	cloneErrors := func() float64 {
+		return testutil.ToFloat64(
+			networkpolicy.NetworkPolicyGitOperationsTotal.WithLabelValues("clone", "error"))
+	}
+	before := cloneErrors()
+
+	var cm corev1.ConfigMap
+	if err := pe.direct.Get(pe.ctx,
+		types.NamespacedName{Name: npErrCMName, Namespace: poisonOpNS}, &cm); err != nil {
+		t.Fatal(err)
+	}
+	cm.Data["whitelist.txt"] += "\nCN=COMPANY-K8S-" + npErrTargetNS + "-viewer,OU=Openshift,DC=example,DC=com"
+	if err := pe.direct.Update(pe.ctx, &cm); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForPoison(t, 90*time.Second, "retry of the failed namespace (clone attempt counter)", func() bool {
+		return cloneErrors() > before
+	})
+
+	// Still failing, so the entry must still be there and still say "error"
+	entry = getNPErrorEntry(t, pe)
+	if entry == nil || entry.State != "error" || entry.ErrorMessage == "" {
+		t.Fatalf("error entry must survive a failed retry, got: %+v", entry)
+	}
+}


### PR DESCRIPTION
Fixes #54

## The three cooperating defects

1. **Dead error-status path** — `updateNetworkPolicyStatus` had zero call sites; the event-driven batch loop logged a per-namespace git failure and dropped it, so `status.networkPolicies` never carried the error (e2e test 53's assertion). The batch loop now records a `state: error` entry with the sanitized error message.
2. **Pointer-vs-copy append bug** — for a first-time namespace the function appended a copy and then assigned `ErrorMessage`/`CreatedAt` to a dangling local. Rewritten as append-then-relookup, hardened with the same fresh-read + conflict-retry pattern as `updateNetworkPolicyStatusWithPR`. `ErrorMessage` is assigned unconditionally (empty clears), sanitized, and bounded to 1 KiB (rune-safe cut).
3. **Retry-filter trap** — the event-driven pass skipped every namespace with a status entry and the periodic pass only considers `pr-merged`, so a naive error entry would have made the failure permanent. The filter (`selectNamespacesForEventDrivenProcessing`) now re-processes entries in retryable states (`error`, and defensively `""`).

Recovery is symmetric: a retry that creates a PR replaces the entry via `updateNetworkPolicyStatusWithPR` (which now also clears the stale `ErrorMessage`); a retry with nothing left to do drops the stale entry, restoring pre-failure semantics.

## Hardening from the adversarial review pass

- **Credential leak closed**: `err.Error()` now lands in CR status, and the `detectGitProvider` failure path embeds the raw repo URL (which may carry inline `user:token@`). `updateNetworkPolicyStatus` sanitizes the message (defense in depth), and `sanitizeString` now applies the generic URL-credential patterns even with nil credentials, matching `sanitizeError`.
- **Spec tear closed**: status write-back copies `Status` + `resourceVersion` only (`syncStatusFromFresh`) instead of replacing the caller's whole object — the old `*permissionBinder = freshBinder` swap (pre-existing in `updateNetworkPolicyStatusWithPR`/`CleanupStatus`, now on the failure hot path) could pull a concurrently edited Spec into a running batch and nil-panic `ProcessNetworkPolicyForNamespace`.
- **Existing-open-PR skip path now records the PR** (`pr-pending`): previously such namespaces had no entry and were re-cloned on every event-driven pass, and with this fix an error entry would have been dropped there instead of transitioning.
- **Metric actually exported**: `permission_binder_networkpolicy_git_operations_total` was incremented but never registered with the metrics registry, so e2e test 53's metric check could never see it. Now registered (exported as `NetworkPolicyGitOperationsTotal`).
- Removed the double `failed to clone repository:` wrap; removed the now prod-unused `hasNetworkPolicyStatus`; e2e test 53 harness no longer passes its metric check spuriously when curl fails (empty value defaulted to 0).

## Behavior notes / known limitations (deliberately out of scope)

- **Retry cadence unchanged**: the main reconcile skip guard (unchanged ConfigMap version + role mapping) gates all NetworkPolicy processing, so error entries are retried on the passes that run at all — the same cadence the pre-fix code retried entry-less failed namespaces. No `RequeueAfter` added. (Observation while here: periodic NP drift detection is also gated behind that guard — pre-existing.)
- If the error-status write itself fails after 3 conflict retries, it is logged and dropped (pre-fix parity for that window).
- An `error` entry for a namespace later added to `excludeNamespaces` lingers without retry or cleanup (exclusion filters run before the NP pass; cleanup keeps whitelisted namespaces). Pre-existing exclusion semantics; flagged for a follow-up.
- `docs/SEQUENCE_DIAGRAMS.md` shows a `drift-detected` state that does not exist in the API — pre-existing doc drift, untouched.

## Verification

- **Full non-mutating suite** (envtest apiserver 1.36.2): branch green, `0 FAIL` — main baseline 588 pass / 0 fail / 3 skip, branch adds 17 regression tests, all green (`go vet`, `gofmt` clean).
- **New regression tests**: unit (append bug, clear-on-success, sanitization, rune-safe truncation, retryable-state table, clear-entry guards), batch-level (filter selection, failure recording, retry + stale-entry drop, PR-creating recovery, hermetic end-to-end clone failure against `127.0.0.1:1`), and a **manager-driven envtest mirror of e2e test 53** (`TestNetworkPolicyGitFailureSurfacesInStatus`): real manager + watch-driven reconciles, asserts the error entry surfaces and that a ConfigMap bump re-processes the failed namespace (clone-attempt counter grows) despite the existing entry.
- **Mutation testing** (each defect re-introduced in isolation, tests must fail): D1 log-and-continue → 4/4 expected tests failed; D2 append-copy → 5/5 failed (State landed via the literal, `ErrorMessage` dropped — exactly the original bug); D3 old skip-filter → 4/4 failed (envtest phase 2 timed out, proving the naive-fix permanence trap). No vacuous tests.
- e2e test 53 on a live cluster remains the final acceptance check (not run here — needs cluster-admin deploy + real GitHub PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
