### PR TITLE
e2e: route fixture-repo gh calls through the gitops token + legacy-operator guards + test-61 seed retry

### DIFF
--- a/example/tests/NETWORKPOLICY_TESTING.md
+++ b/example/tests/NETWORKPOLICY_TESTING.md
@@ -39,17 +39,39 @@ Each NetworkPolicy test:
 
 ### GitHub Authentication
 
-**Option 1: gh CLI authentication**
+**Fixture-repo calls are routed through `np_gh` (test-common.sh), not ambient
+`gh` auth.** `np_gh` resolves the SAME token the operator uses (the
+`github-gitops-credentials` Secret): first from the plaintext manifest
+`temp/github-gitops-credentials-secret.yaml` at the repo root, then from the
+in-cluster Secret, and only falls back to ambient `gh` auth when neither
+resolves. This matters because an ambient PAT scoped to a different repo makes
+every cleanup ref-delete fail with 403 — stale `networkpolicy/*` branches and
+PRs then accumulate and break later runs with existing-branch conflicts.
+
+**Token scope requirements** (fine-grained PAT on the fixture repo):
+
+- **Contents: Read and write** — file cleanup, template updates (test 56)
+- **Pull requests: Read and write** — PR verification, close, branch delete
+- **Issues: Read and write** — label attach (test 49 `auto-merge` label)
+- **Merge/admin rights on the repo** — tests 54 and 56 merge PRs with
+  `gh pr merge --admin`
+
+Never point `np_gh` at the test-created `-readonly`/`-invalid` secrets
+(tests 53/57 deliberately provision underpowered tokens).
+
+**Ambient fallback (only when no token resolves)**
 ```bash
 gh auth login
-# Follow prompts to authenticate
+# Follow prompts to authenticate — the account/PAT must cover the fixture repo
 ```
 
-**Option 2: Use token from Secret**
+**Manual debugging with the operator's token**
 ```bash
 # Token is in temp/github-gitops-credentials-secret.yaml
 # gh CLI can use GITHUB_TOKEN environment variable
-export GITHUB_TOKEN=$(kubectl get secret github-gitops-credentials -n permissions-binder-operator -o jsonpath='{.data.token}' | base64 -d)
+# NAMESPACE = this instance's operator namespace
+# (default: permissions-binder-operator; pbo-e2e-${INSTANCE} under INSTANCE mode)
+export GITHUB_TOKEN=$(kubectl get secret github-gitops-credentials -n ${NAMESPACE} -o jsonpath='{.data.token}' | base64 -d)
 ```
 
 ### Verify Setup

--- a/example/tests/run-tests-full-isolation.sh
+++ b/example/tests/run-tests-full-isolation.sh
@@ -239,6 +239,38 @@ else
 fi
 echo "" | tee -a $RESULTS_LOG
 
+# INSTANCE-mode preflight: refuse to run beside a leftover LEGACY operator.
+# An instance-rendered operator always carries the RECONCILE_NAMESPACES env
+# (injected by render_instance_manifests above); the committed manifest has it
+# commented out, so a controller-manager Deployment WITHOUT that env watches
+# the whole cluster. Such a leftover (typically the last pool-C test of a
+# previous run - per-test cleanup runs BEFORE each test) races this instance's
+# operator for resource ownership (first-owner-wins): resources get the
+# default managed-by label and the instance-scoped counts silently read 0.
+# Escape hatch: E2E_ALLOW_LEGACY=1 proceeds anyway (logged as a warning).
+if [ -n "${INSTANCE:-}" ]; then
+    LEGACY_OPERATORS=$(kubectl get deploy -A -l control-plane=controller-manager -o json 2>/dev/null \
+        | jq -r --arg ns "$NAMESPACE" '.items[]
+            | select(.metadata.namespace != $ns)
+            | select(([.spec.template.spec.containers[0].env[]?.name] | index("RECONCILE_NAMESPACES")) | not)
+            | .metadata.namespace + "/" + .metadata.name')
+    if [ -n "$LEGACY_OPERATORS" ]; then
+        if [ "${E2E_ALLOW_LEGACY:-0}" = "1" ]; then
+            echo -e "${YELLOW}⚠️  E2E_ALLOW_LEGACY=1: proceeding despite legacy (cluster-wide) operator(s):${NC}" | tee -a $RESULTS_LOG
+            echo "$LEGACY_OPERATORS" | sed 's/^/   ⚠️  /' | tee -a $RESULTS_LOG
+        else
+            echo -e "${RED}❌ PREFLIGHT: legacy (cluster-wide) operator(s) detected outside $NAMESPACE:${NC}" | tee -a $RESULTS_LOG
+            echo "$LEGACY_OPERATORS" | sed 's/^/   ❌ /' | tee -a $RESULTS_LOG
+            echo "   A cluster-wide operator races this instance's operator for resource" | tee -a $RESULTS_LOG
+            echo "   ownership (first-owner-wins) and silently corrupts instance-scoped" | tee -a $RESULTS_LOG
+            echo "   assertions. Clean it up first:" | tee -a $RESULTS_LOG
+            echo "       ./cleanup-operator.sh   # legacy mode (no INSTANCE env)" | tee -a $RESULTS_LOG
+            echo "   or set E2E_ALLOW_LEGACY=1 to proceed anyway." | tee -a $RESULTS_LOG
+            exit 1
+        fi
+    fi
+fi
+
 # Pre-load test names
 for test_id in "${TEST_LIST[@]}"; do
     test_names[$test_id]=$(get_test_name $test_id)

--- a/example/tests/run-tests-parallel.sh
+++ b/example/tests/run-tests-parallel.sh
@@ -171,6 +171,22 @@ else
 fi
 log ""
 
+# Pre-parallel legacy sweep (issue #55): per-test cleanup runs BEFORE each
+# test, so the LAST pool-C test of a previous run leaves its cluster-wide
+# operator running. That leftover races this run's instance operators for
+# ownership (first-owner-wins -> resources get the default managed-by label
+# and the instance-scoped counts read 0). Sweep it in LEGACY mode (no
+# INSTANCE / TEST_NS_PREFIX env -> cleanup defaults to the
+# permissions-binder-operator namespace + the unanchored regex namespace
+# sweep) - safe here because no slots are running yet.
+log "🧹 Pre-parallel sweep: removing legacy (non-instance) operator leftovers..."
+if "$SCRIPT_DIR/cleanup-operator.sh" >>"/tmp/e2e-parallel-${SUITE_ID}-legacy-sweep.log" 2>&1; then
+    log "   ✅ Legacy leftovers swept"
+else
+    log "   ⚠️  Legacy sweep had warnings (/tmp/e2e-parallel-${SUITE_ID}-legacy-sweep.log)"
+fi
+log ""
+
 # ---------------------------------------------------------------------------
 # Shard pools A (+solo heavy) and B across N slots in round-robin order.
 # ---------------------------------------------------------------------------

--- a/example/tests/test-common.sh
+++ b/example/tests/test-common.sh
@@ -20,6 +20,64 @@ info_log() {
     echo "ℹ️  $1" | tee -a ${TEST_RESULTS:-/tmp/e2e-test-results.log}
 }
 
+# ---------------------------------------------------------------------------
+# GitHub token routing for the NetworkPolicy fixture repo (v1.8.0 campaign)
+#
+# The ambient `gh` login may be scoped to a DIFFERENT repository than the
+# NetworkPolicy fixture repo (lukasz-bielinski/tests-network-policies). When it
+# is, every cleanup ref-delete 403s silently and stale networkpolicy/* branches
+# and PRs accumulate until they break later runs with existing-branch
+# conflicts. All fixture-repo verification/cleanup therefore routes through
+# np_gh, which authenticates with the SAME token the operator itself uses: the
+# github-gitops-credentials Secret. ALWAYS that Secret — never the
+# test-created -readonly/-invalid secrets (tests 53/57 deliberately provision
+# underpowered tokens; using those for cleanup would leak fixture-repo
+# artifacts).
+#
+# Token scope requirements are documented in NETWORKPOLICY_TESTING.md:
+# Contents RW + Pull requests RW + Issues RW (labels); tests 54/56 merge PRs
+# with --admin and additionally need merge/admin rights on the fixture repo.
+#
+# Resolution order (cached after the first call):
+#   1. Plaintext manifest temp/github-gitops-credentials-secret.yaml at the
+#      repo root (file-first: per-test cleanup DELETES the in-cluster Secret,
+#      so it is often absent exactly when cleanup needs the token).
+#   2. In-cluster Secret github-gitops-credentials in $NAMESPACE.
+#   3. Empty -> np_gh falls back to ambient gh auth (previous behavior).
+# ---------------------------------------------------------------------------
+
+_NP_TOKEN=""
+_NP_TOKEN_RESOLVED=""
+
+# get_np_token - print the operator's GitHub token (empty if unresolvable)
+get_np_token() {
+    if [ -z "$_NP_TOKEN_RESOLVED" ]; then
+        local secret_file="${SCRIPT_DIR:-.}/../../temp/github-gitops-credentials-secret.yaml"
+        if [ -f "$secret_file" ]; then
+            _NP_TOKEN=$(awk -F'"' '/^[[:space:]]*token:[[:space:]]*"/ {print $2; exit}' "$secret_file" 2>/dev/null)
+        fi
+        if [ -z "$_NP_TOKEN" ]; then
+            _NP_TOKEN=$(kubectl get secret github-gitops-credentials \
+                -n "${NAMESPACE:-permissions-binder-operator}" \
+                -o jsonpath='{.data.token}' 2>/dev/null | base64 -d 2>/dev/null)
+        fi
+        _NP_TOKEN_RESOLVED=1
+    fi
+    printf '%s' "$_NP_TOKEN"
+}
+
+# np_gh - gh CLI authenticated with the operator's fixture-repo token.
+# Falls back to ambient gh auth when no token resolves.
+np_gh() {
+    local token
+    token="$(get_np_token)"
+    if [ -n "$token" ]; then
+        GH_TOKEN="$token" gh "$@"
+    else
+        gh "$@"
+    fi
+}
+
 # E2E_WAIT_MULT (default 1) multiplies harness-owned fixed sleeps/timeouts.
 # The k3s API server on rpi4-class hardware is loaded when the suite runs in
 # parallel (issue #36); the parallel runner exports a load-aware default.
@@ -305,7 +363,7 @@ verify_pr_on_github() {
     fi
     
     # Check if gh is authenticated
-    if ! gh auth status &>/dev/null; then
+    if ! np_gh auth status &>/dev/null; then
         info_log "⚠️  gh CLI not authenticated, skipping GitHub PR verification"
         return 1
     fi
@@ -318,7 +376,7 @@ verify_pr_on_github() {
     fi
     
     # Get PR details
-    local pr_json=$(gh pr view "$pr_number" --repo "$repo" --json number,state,title,headRefName,url,labels 2>/dev/null)
+    local pr_json=$(np_gh pr view "$pr_number" --repo "$repo" --json number,state,title,headRefName,url,labels 2>/dev/null)
     if [ $? -eq 0 ] && [ -n "$pr_json" ]; then
         echo "$pr_json"
         return 0
@@ -351,7 +409,7 @@ verify_pr_files() {
     fi
     
     # Get PR files
-    local pr_files=$(gh pr view "$pr_number" --repo "$repo" --json files --jq '.files[].path' 2>/dev/null)
+    local pr_files=$(np_gh pr view "$pr_number" --repo "$repo" --json files --jq '.files[].path' 2>/dev/null)
     if [ $? -ne 0 ] || [ -z "$pr_files" ]; then
         return 1
     fi
@@ -397,7 +455,7 @@ verify_pr_file_content() {
     fi
     
     # Get file content from PR
-    local file_content=$(gh pr view "$pr_number" --repo "$repo" --json files --jq ".files[] | select(.path==\"$file_path\") | .additions" 2>/dev/null)
+    local file_content=$(np_gh pr view "$pr_number" --repo "$repo" --json files --jq ".files[] | select(.path==\"$file_path\") | .additions" 2>/dev/null)
     if [ $? -ne 0 ] || [ -z "$file_content" ]; then
         return 1
     fi
@@ -432,7 +490,7 @@ verify_kustomization_paths() {
     fi
     
     # Get PR diff for kustomization.yaml
-    local diff_output=$(gh pr diff "$pr_number" --repo "$repo" "$kustomization_path" 2>/dev/null)
+    local diff_output=$(np_gh pr diff "$pr_number" --repo "$repo" "$kustomization_path" 2>/dev/null)
     if [ $? -ne 0 ]; then
         return 1
     fi
@@ -490,16 +548,16 @@ cleanup_pr_and_branch() {
     info_log "Cleaning up PR $pr_number and branch $branch_name from GitHub..."
     
     # Close PR if it's still open
-    local pr_state=$(gh pr view "$pr_number" --repo "$repo" --json state --jq '.state' 2>/dev/null || echo "")
+    local pr_state=$(np_gh pr view "$pr_number" --repo "$repo" --json state --jq '.state' 2>/dev/null || echo "")
     if [ "$pr_state" == "OPEN" ]; then
         info_log "Closing PR $pr_number..."
-        gh pr close "$pr_number" --repo "$repo" --delete-branch=false 2>/dev/null || true
+        np_gh pr close "$pr_number" --repo "$repo" --delete-branch=false 2>/dev/null || true
     fi
     
     # Delete branch if it exists
     if [ -n "$branch_name" ] && [ "$branch_name" != "" ]; then
         info_log "Deleting branch $branch_name..."
-        gh api repos/"$repo"/git/refs/heads/"$branch_name" -X DELETE 2>/dev/null || true
+        np_gh api repos/"$repo"/git/refs/heads/"$branch_name" -X DELETE 2>/dev/null || true
     fi
     
     info_log "✅ Cleanup completed for PR $pr_number"
@@ -522,14 +580,14 @@ delete_file_from_github() {
     fi
     
     # Get file SHA (required for deletion)
-    local file_sha=$(gh api repos/"$repo"/contents/"$file_path" --jq '.sha' 2>/dev/null || echo "")
+    local file_sha=$(np_gh api repos/"$repo"/contents/"$file_path" --jq '.sha' 2>/dev/null || echo "")
     if [ -z "$file_sha" ] || [ "$file_sha" == "null" ]; then
         # File doesn't exist, nothing to delete
         return 0
     fi
     
     # Delete file using GitHub API
-    gh api repos/"$repo"/contents/"$file_path" \
+    np_gh api repos/"$repo"/contents/"$file_path" \
         -X DELETE \
         -f message="$commit_message" \
         -f sha="$file_sha" \
@@ -568,7 +626,7 @@ cleanup_networkpolicy_files_from_repo() {
         local deleted_count=0
         
         # List all items in directory (files and subdirectories)
-        local items=$(gh api repos/"$github_repo"/contents/"$dir_path" --jq '.[].name' 2>/dev/null || echo "")
+        local items=$(np_gh api repos/"$github_repo"/contents/"$dir_path" --jq '.[].name' 2>/dev/null || echo "")
         
         if [ -z "$items" ] || [ "$items" == "" ]; then
             echo 0
@@ -581,7 +639,7 @@ cleanup_networkpolicy_files_from_repo() {
             
             # Check if it's a file or directory
             # For directories, API returns array; for files, it returns object with 'type' field
-            local item_info=$(gh api repos/"$github_repo"/contents/"$item_path" 2>/dev/null || echo "")
+            local item_info=$(np_gh api repos/"$github_repo"/contents/"$item_path" 2>/dev/null || echo "")
             local item_json_type=$(echo "$item_info" | jq -r 'if type=="array" then "dir" else .type end' 2>/dev/null || echo "")
             
             if [ "$item_json_type" == "file" ]; then
@@ -659,7 +717,7 @@ cleanup_networkpolicy_test_artifacts() {
         info_log "⚠️  No PR number found in status, trying to find PR from GitHub..."
         if command -v gh &> /dev/null && command -v jq &> /dev/null; then
             local branch_name="networkpolicy/${cluster_name}/${test_namespace}"
-            pr_number=$(gh pr list --repo "$github_repo" --head "$branch_name" --state all --json number --limit 1 --jq '.[0].number' 2>/dev/null || echo "")
+            pr_number=$(np_gh pr list --repo "$github_repo" --head "$branch_name" --state all --json number --limit 1 --jq '.[0].number' 2>/dev/null || echo "")
             if [ -n "$pr_number" ] && [ "$pr_number" != "null" ] && [ "$pr_number" != "" ]; then
                 info_log "Found PR number from GitHub: $pr_number"
             fi
@@ -679,10 +737,10 @@ cleanup_networkpolicy_test_artifacts() {
     if [ -z "$pr_branch" ] || [ "$pr_branch" == "" ] || [ -z "$pr_state" ] || [ "$pr_state" == "" ]; then
         if command -v gh &> /dev/null && command -v jq &> /dev/null; then
             if [ -z "$pr_branch" ] || [ "$pr_branch" == "" ]; then
-                pr_branch=$(gh pr view "$pr_number" --repo "$github_repo" --json headRefName --jq '.headRefName' 2>/dev/null || echo "")
+                pr_branch=$(np_gh pr view "$pr_number" --repo "$github_repo" --json headRefName --jq '.headRefName' 2>/dev/null || echo "")
             fi
             if [ -z "$pr_state" ] || [ "$pr_state" == "" ]; then
-                pr_state=$(gh pr view "$pr_number" --repo "$github_repo" --json state --jq '.state' 2>/dev/null || echo "")
+                pr_state=$(np_gh pr view "$pr_number" --repo "$github_repo" --json state --jq '.state' 2>/dev/null || echo "")
             fi
         fi
     fi

--- a/example/tests/test-implementations/test-44-networkpolicy---variant-a-new-file-from-template.sh
+++ b/example/tests/test-implementations/test-44-networkpolicy---variant-a-new-file-from-template.sh
@@ -137,7 +137,7 @@ verify_pr_for_namespace() {
             info_log "PR state found: $pr_state, but PR number missing. Checking GitHub for recent PRs..."
             if command -v gh &> /dev/null; then
                 # Get most recent PR for namespace (branch pattern: networkpolicy/DEV-cluster/$namespace)
-                pr_number=$(gh pr list --repo "$GITHUB_REPO" --head "networkpolicy/DEV-cluster/$namespace" --state all --json number,title,state --limit 1 --jq '.[0].number' 2>/dev/null || echo "")
+                pr_number=$(np_gh pr list --repo "$GITHUB_REPO" --head "networkpolicy/DEV-cluster/$namespace" --state all --json number,title,state --limit 1 --jq '.[0].number' 2>/dev/null || echo "")
                 if [ -n "$pr_number" ] && [ "$pr_number" != "null" ] && [ "$pr_number" != "" ]; then
                     info_log "Found PR number from GitHub: $pr_number"
                 fi
@@ -213,7 +213,7 @@ verify_pr_for_namespace() {
         
         # Verify PR description contains expected information
         if command -v jq &> /dev/null; then
-            local pr_description=$(gh pr view "$pr_number" --repo "$GITHUB_REPO" --json body --jq '.body' 2>/dev/null || echo "")
+            local pr_description=$(np_gh pr view "$pr_number" --repo "$GITHUB_REPO" --json body --jq '.body' 2>/dev/null || echo "")
             if [ -n "$pr_description" ] && [ "$pr_description" != "null" ]; then
                 if echo "$pr_description" | grep -q "$namespace"; then
                     pass_test "PR description contains namespace: $namespace"

--- a/example/tests/test-implementations/test-45-networkpolicy---variant-b-backup-existing-template-based-policy.sh
+++ b/example/tests/test-implementations/test-45-networkpolicy---variant-b-backup-existing-template-based-policy.sh
@@ -142,7 +142,7 @@ verify_pr_for_namespace() {
         if [ "$pr_state" == "pr-merged" ] || [ "$pr_state" == "pr-pending" ]; then
             info_log "PR state found: $pr_state, but PR number missing. Checking GitHub for recent PRs..."
             if command -v gh &> /dev/null; then
-                pr_number=$(gh pr list --repo "$GITHUB_REPO" --head "networkpolicy/DEV-cluster/$namespace" --state all --json number,title,state --limit 1 --jq '.[0].number' 2>/dev/null || echo "")
+                pr_number=$(np_gh pr list --repo "$GITHUB_REPO" --head "networkpolicy/DEV-cluster/$namespace" --state all --json number,title,state --limit 1 --jq '.[0].number' 2>/dev/null || echo "")
                 if [ -n "$pr_number" ] && [ "$pr_number" != "null" ] && [ "$pr_number" != "" ]; then
                     info_log "Found PR number from GitHub: $pr_number"
                 fi

--- a/example/tests/test-implementations/test-49-networkpolicy---auto-merge-pr.sh
+++ b/example/tests/test-implementations/test-49-networkpolicy---auto-merge-pr.sh
@@ -136,7 +136,7 @@ IFS='|' read -r pr_num pr_url pr_branch pr_state <<< "$(parse_pr_details "$pr_de
 # Ensure auto-merge label exists (GH API doesn't attach labels on PR creation)
 if command -v gh &> /dev/null; then
     info_log "Ensuring auto-merge label is attached to PR $pr_number"
-    if ! gh pr edit "$pr_number" --repo "$GITHUB_REPO" --add-label "auto-merge" >/dev/null 2>&1; then
+    if ! np_gh pr edit "$pr_number" --repo "$GITHUB_REPO" --add-label "auto-merge" >/dev/null 2>&1; then
         info_log "⚠️  Could not add auto-merge label via gh CLI (may require manual check)"
     fi
 else
@@ -208,7 +208,7 @@ if [ $? -eq 0 ] && [ -n "$pr_json" ]; then
         if command -v gh &> /dev/null; then
             # Check if file exists in main branch
             file_path="networkpolicies/DEV-cluster/$TEST_NAMESPACE/$TEST_NAMESPACE-deny-all-ingress.yaml"
-            if gh api repos/"$GITHUB_REPO"/contents/"$file_path" --jq '.name' 2>/dev/null | grep -q "deny-all-ingress.yaml"; then
+            if np_gh api repos/"$GITHUB_REPO"/contents/"$file_path" --jq '.name' 2>/dev/null | grep -q "deny-all-ingress.yaml"; then
                 pass_test "NetworkPolicy file exists in main branch after merge"
             else
                 info_log "⚠️  NetworkPolicy file not found in main branch (may need more time for merge to complete)"

--- a/example/tests/test-implementations/test-51-networkpolicy---rate-limiting-handling.sh
+++ b/example/tests/test-implementations/test-51-networkpolicy---rate-limiting-handling.sh
@@ -73,7 +73,7 @@ fi
 # Check current GitHub API rate limit status
 info_log "Checking GitHub API rate limit status..."
 if command -v gh &> /dev/null; then
-    RATE_LIMIT=$(gh api rate_limit --jq '.rate.remaining' 2>/dev/null || echo "unknown")
+    RATE_LIMIT=$(np_gh api rate_limit --jq '.rate.remaining' 2>/dev/null || echo "unknown")
     info_log "GitHub API rate limit remaining: $RATE_LIMIT"
 fi
 

--- a/example/tests/test-implementations/test-52-networkpolicy---variant-c-backup-non-template.sh
+++ b/example/tests/test-implementations/test-52-networkpolicy---variant-c-backup-non-template.sh
@@ -150,7 +150,7 @@ verify_pr_for_namespace() {
         if [ "$pr_state" == "pr-merged" ] || [ "$pr_state" == "pr-pending" ]; then
             info_log "PR state found: $pr_state, but PR number missing. Checking GitHub for recent PRs..."
             if command -v gh &> /dev/null; then
-                pr_number=$(gh pr list --repo "$GITHUB_REPO" --head "networkpolicy/DEV-cluster/$namespace" --state all --json number,title,state --limit 1 --jq '.[0].number' 2>/dev/null || echo "")
+                pr_number=$(np_gh pr list --repo "$GITHUB_REPO" --head "networkpolicy/DEV-cluster/$namespace" --state all --json number,title,state --limit 1 --jq '.[0].number' 2>/dev/null || echo "")
                 if [ -n "$pr_number" ] && [ "$pr_number" != "null" ] && [ "$pr_number" != "" ]; then
                     info_log "Found PR number from GitHub: $pr_number"
                 fi

--- a/example/tests/test-implementations/test-54-networkpolicy---pr-state-transitions.sh
+++ b/example/tests/test-implementations/test-54-networkpolicy---pr-state-transitions.sh
@@ -114,7 +114,7 @@ pass_test "PR created (number: $PR_NUMBER, initial state: ${INITIAL_STATE:-unkno
 # 5. Merge PR using gh CLI
 # ----------------------------------------------------------------------------
 info_log "Merging PR $PR_NUMBER via gh CLI"
-if ! gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPO" --merge --admin >/dev/null 2>&1; then
+if ! np_gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPO" --merge --admin >/dev/null 2>&1; then
     info_log "⚠️  gh pr merge failed (perhaps already merged); attempting status check"
 else
     pass_test "PR $PR_NUMBER merged via gh CLI"

--- a/example/tests/test-implementations/test-56-networkpolicy---template-changes-detection.sh
+++ b/example/tests/test-implementations/test-56-networkpolicy---template-changes-detection.sh
@@ -35,7 +35,7 @@ UPDATED_TEMPLATE_SHA=""
 cleanup_resources() {
     if [ -n "$UPDATED_TEMPLATE_SHA" ] && [ -n "$ORIGINAL_TEMPLATE_BASE64" ]; then
         info_log "Reverting template file to original content"
-        gh api repos/"$GITHUB_REPO"/contents/"$TEMPLATE_PATH" \
+        np_gh api repos/"$GITHUB_REPO"/contents/"$TEMPLATE_PATH" \
             -X PUT \
             -f message="Test 56: revert template update" \
             -f sha="$UPDATED_TEMPLATE_SHA" \
@@ -124,7 +124,7 @@ fi
 pass_test "Initial PR created (number: $INITIAL_PR)"
 
 # Merge initial PR to simulate steady state
-if ! gh pr merge "$INITIAL_PR" --repo "$GITHUB_REPO" --merge --admin >/dev/null 2>&1; then
+if ! np_gh pr merge "$INITIAL_PR" --repo "$GITHUB_REPO" --merge --admin >/dev/null 2>&1; then
     info_log "⚠️  Failed to merge initial PR automatically (may already be merged or checks failing)"
 fi
 
@@ -135,7 +135,7 @@ wait_for_pr_state "$BINDER_NAME" "$TEST_NAMESPACE" "pr-merged" 120 >/dev/null 2>
 # 4. Modify template file to trigger template change detection
 # ----------------------------------------------------------------------------
 info_log "Fetching current template content"
-TEMPLATE_JSON=$(gh api repos/"$GITHUB_REPO"/contents/"$TEMPLATE_PATH" 2>/dev/null)
+TEMPLATE_JSON=$(np_gh api repos/"$GITHUB_REPO"/contents/"$TEMPLATE_PATH" 2>/dev/null)
 if [ -z "$TEMPLATE_JSON" ]; then
     fail_test "Failed to fetch template content from GitHub"
     exit 1
@@ -153,7 +153,7 @@ echo "# Test 56 template update at $TIMESTAMP" >> "$TMP_TEMPLATE"
 
 UPDATED_TEMPLATE_BASE64=$(base64 < "$TMP_TEMPLATE" | tr -d '\n')
 info_log "Updating template in GitHub to simulate change"
-UPDATE_RESPONSE=$(gh api repos/"$GITHUB_REPO"/contents/"$TEMPLATE_PATH" \
+UPDATE_RESPONSE=$(np_gh api repos/"$GITHUB_REPO"/contents/"$TEMPLATE_PATH" \
     -X PUT \
     -f message="Test 56: template update" \
     -f sha="$ORIGINAL_TEMPLATE_SHA" \

--- a/example/tests/test-implementations/test-61-ldap-mock-group-creation.sh
+++ b/example/tests/test-implementations/test-61-ldap-mock-group-creation.sh
@@ -128,10 +128,20 @@ if ! load_ldif_ok "$SCHEMA_OUT" "$SCHEMA_RC"; then
     exit 1
 fi
 
-DATA_OUT=$(kubectl exec -i -n "$MOCK_NS" deploy/openldap -- \
-    ldapadd -x -H ldap://localhost:389 \
-    -D "$LDAP_ADMIN_DN" -w "$LDAP_ADMIN_PW" < "$MOCK_DIR/02b-init-data.ldif" 2>&1)
-DATA_RC=$?
+# Retry like the schema load above: slapd over ldap:// can still refuse
+# connections for a few seconds after the TCP probe passes (observed:
+# "Can't contact LDAP server (-1)" flake). Not kubectl_retry - it re-invokes
+# the command for its error check and only matches connection-refused-style
+# API server errors, the wrong failure mode here.
+DATA_OUT=""; DATA_RC=1
+for attempt in 1 2 3; do
+    DATA_OUT=$(kubectl exec -i -n "$MOCK_NS" deploy/openldap -- \
+        ldapadd -x -H ldap://localhost:389 \
+        -D "$LDAP_ADMIN_DN" -w "$LDAP_ADMIN_PW" < "$MOCK_DIR/02b-init-data.ldif" 2>&1)
+    DATA_RC=$?
+    load_ldif_ok "$DATA_OUT" "$DATA_RC" && break
+    e2e_sleep 5
+done
 if ! load_ldif_ok "$DATA_OUT" "$DATA_RC"; then
     fail_test "OU seed load failed: $DATA_OUT"
     exit 1


### PR DESCRIPTION
Four harness defects from the 2026-08-24 v1.8.0 validation campaign, each evidence-backed:

## 1. Token routing (`np_gh` / `get_np_token`) — commit 1
All GitHub-touching helpers used **ambient `gh` auth**; with a wrong-scoped ambient PAT every ref-delete 403'd, silently accumulating **41 stale `networkpolicy/*` branches + 15 PRs** that then broke 7 NP tests in the release-gate run (existing-branch conflicts) and made tests 54/56 unable to merge PRs. Helpers now resolve the token like the operator does: `temp/github-gitops-credentials-secret.yaml` → in-cluster `github-gitops-credentials` Secret (in `$NAMESPACE`) → ambient fallback. Never reads test-created `-readonly`/`-invalid` secrets. Guard/return-code semantics preserved. Docs updated with scope requirements (Contents RW, PR RW, Issues RW; merge/admin for tests 54/56).

## 2. Pre-parallel legacy sweep — commit 2
Per-test cleanup runs *before* each test, so the last pool-C test's cluster-wide operator survives a suite and races the next run's instance operators (issue #55's false alarm — first-owner-wins → default-labeled resources → instance-label counts read 0). The parallel runner now sweeps the legacy operator once before sharding.

## 3. Instance-mode preflight guard — commit 3
A standalone `INSTANCE=N` run now fails fast (exit 1, ~1s) when a cluster-wide operator (no `RECONCILE_NAMESPACES` env) is running outside `$NAMESPACE`; `E2E_ALLOW_LEGACY=1` bypasses with a warning.

## 4. test-61 OU-seed retry — commit 4
The OU seed was a single shot while the schema load already retried ×3 — one observed `Can't contact LDAP server (-1)` startup flake. Now mirrored.

## Live validation (k3s)
- Routing: zero `403`/`Resource not accessible` lines across all runs; the secret token closed 9 stale PRs + deleted 9 branches the ambient PAT could not; fixture repo left with 0 `networkpolicy/*` branches.
- Guard: trips in ~1s naming the offender; the `E2E_ALLOW_LEGACY=1` bypass run **empirically reproduced the exact race the guard prevents** (legacy operator claimed the baseline namespace with the default label).
- test-61 ×2 back-to-back PASS; cluster and fixture repo left clean.

## Known pre-existing issue surfaced by validation (NOT addressed here)
In instance mode, NP tests' own PermissionBinders share ConfigMap `permission-config` with the runner's baseline PB → first-owner-wins splits target namespaces between the two CRs (test 44's `test-app-2` loses deterministically). Same class as the SA-tests collision fixed earlier (self-contained ConfigMaps); follow-up issue to be filed — the fix pattern is known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)