### PR TITLE
e2e: self-contained NetworkPolicy tests, modernized 54/56 flows, ordered cleanup (Closes #59)

### DIFF
--- a/example/tests/cleanup-operator.sh
+++ b/example/tests/cleanup-operator.sh
@@ -69,22 +69,65 @@ if [ -z "$KUBECONFIG" ]; then
     exit 1
 fi
 
-echo "Step 1: Remove PermissionBinder CR (triggers finalizer)"
+# PermissionBinder deletion MUST complete (verified gone) BEFORE the operator
+# deployment is removed: once the operator is gone nothing processes the PB
+# finalizers, the CRs stay Terminating forever and the namespace deletion in
+# Step 7 wedges on them (issue #59). The finalizer-strip fallback below also
+# covers PBs stranded inside an already-Terminating namespace from a previous
+# failed cleanup (patch works in Terminating namespaces; create does not).
+
+list_permissionbinders() {
+    kubectl get permissionbinder -n "$NAMESPACE" -o name 2>/dev/null || true
+}
+
+echo "Step 1: Remove PermissionBinder CRs (triggers finalizer)"
 echo "--------------------------------------------------------"
-kubectl get permissionbinder -n "$NAMESPACE" 2>/dev/null | grep -v NAME | awk '{print $1}' | while read pb; do
+list_permissionbinders | while read pb; do
+    [ -z "$pb" ] && continue
     echo "Deleting PermissionBinder: $pb"
-    kubectl delete permissionbinder "$pb" -n "$NAMESPACE" --timeout=30s 2>/dev/null || true
+    kubectl delete "$pb" -n "$NAMESPACE" --wait=false 2>/dev/null || true
 done
 
 echo ""
-echo "Step 2: Remove finalizers from stuck PermissionBinder CRs"
-echo "-----------------------------------------------------------"
-kubectl get permissionbinder -n "$NAMESPACE" 2>/dev/null | grep -v NAME | awk '{print $1}' | while read pb; do
-    echo "Patching finalizers for: $pb"
-    kubectl patch permissionbinder "$pb" -n "$NAMESPACE" -p '{"metadata":{"finalizers":[]}}' --type=merge 2>/dev/null || true
+echo "Step 2: Wait until every PermissionBinder is gone (finalizer-strip fallback)"
+echo "-----------------------------------------------------------------------------"
+# Give the still-running operator up to 20s to process finalizers normally,
+# then strip finalizers from whatever is stuck and keep polling (up to 60s).
+PB_WAITED=0
+while [ "$PB_WAITED" -lt 60 ]; do
+    REMAINING_PBS=$(list_permissionbinders)
+    if [ -z "$REMAINING_PBS" ]; then
+        break
+    fi
+    if [ "$PB_WAITED" -ge 20 ]; then
+        echo "$REMAINING_PBS" | while read pb; do
+            [ -z "$pb" ] && continue
+            echo "Stripping finalizers from stuck: $pb"
+            kubectl patch "$pb" -n "$NAMESPACE" -p '{"metadata":{"finalizers":[]}}' --type=merge 2>/dev/null || true
+        done
+    fi
+    sleep 3
+    PB_WAITED=$((PB_WAITED + 3))
 done
 
-sleep 5
+REMAINING_PBS=$(list_permissionbinders)
+if [ -z "$REMAINING_PBS" ]; then
+    echo "✅ All PermissionBinders deleted"
+else
+    # Last resort: strip finalizers once more so the namespace can terminate
+    echo -e "${YELLOW}⚠️  PermissionBinders still present after ${PB_WAITED}s; stripping finalizers once more${NC}"
+    echo "$REMAINING_PBS" | while read pb; do
+        [ -z "$pb" ] && continue
+        kubectl patch "$pb" -n "$NAMESPACE" -p '{"metadata":{"finalizers":[]}}' --type=merge 2>/dev/null || true
+        kubectl delete "$pb" -n "$NAMESPACE" --wait=false 2>/dev/null || true
+    done
+    sleep 3
+    if [ -z "$(list_permissionbinders)" ]; then
+        echo "✅ All PermissionBinders deleted (after finalizer strip)"
+    else
+        echo -e "${RED}❌ PermissionBinders still present; namespace deletion may hang${NC}"
+    fi
+fi
 
 echo ""
 echo "Step 3: Delete operator deployment"

--- a/example/tests/test-common.sh
+++ b/example/tests/test-common.sh
@@ -263,6 +263,39 @@ ${whitelist}
 EOF
 }
 
+# create_np_test_configmap <configmap_name> <namespace[:role]> [more...]
+# NetworkPolicy-test analogue of create_sa_test_configmap (issue #59): a
+# ConfigMap in $NAMESPACE whose whitelist.txt CNs resolve to DEDICATED
+# namespaces, so the NP test's PermissionBinder is the first (and only) owner
+# of everything it manages instead of colliding with the runner's baseline CR
+# on the shared permission-config ConfigMap (first-owner-wins, issue #45).
+# Role defaults to "engineer"; append ":role" to override (e.g. "my-ns:viewer").
+# The PermissionBinder under test must map the role to some ClusterRole.
+create_np_test_configmap() {
+    local cm_name=$1
+    shift
+    local whitelist="" entry ns role
+    for entry in "$@"; do
+        ns=${entry%%:*}
+        role="engineer"
+        case "$entry" in
+            *:*) role=${entry##*:} ;;
+        esac
+        whitelist="${whitelist}    CN=COMPANY-K8S-${ns}-${role},OU=Openshift,DC=example,DC=com"$'\n'
+    done
+    whitelist=${whitelist%$'\n'}
+    apply_yaml_with_retry <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${cm_name}
+  namespace: ${NAMESPACE:?}
+data:
+  whitelist.txt: |
+${whitelist}
+EOF
+}
+
 # wait_for_cmd <timeout_s> <cmd...> - poll every 2s until cmd succeeds.
 # Timeout is scaled by E2E_WAIT_MULT. Returns 1 on timeout.
 wait_for_cmd() {

--- a/example/tests/test-common.sh
+++ b/example/tests/test-common.sh
@@ -296,6 +296,19 @@ ${whitelist}
 EOF
 }
 
+# touch_np_configmap <configmap_name> - annotate the ConfigMap to fire a
+# watch event and force a reconcile pass. The operator has NO timer-driven
+# requeue: "periodic" NetworkPolicy reconciliation (which refreshes PR state
+# from GitHub) only runs inside an event-triggered reconcile once
+# reconciliationInterval has elapsed. After out-of-band GitHub changes (a PR
+# merged by a test, a template edited) nothing fires a Kubernetes event, so
+# the PermissionBinder status never refreshes on its own - verified live in
+# issue #59 (lastNetworkPolicyReconciliation frozen despite a 10s interval).
+touch_np_configmap() {
+    kubectl annotate configmap "$1" -n "${NAMESPACE:?}" \
+        permission-binder.io/e2e-nudge="$(date +%s%N)" --overwrite >/dev/null 2>&1 || true
+}
+
 # wait_for_cmd <timeout_s> <cmd...> - poll every 2s until cmd succeeds.
 # Timeout is scaled by E2E_WAIT_MULT. Returns 1 on timeout.
 wait_for_cmd() {

--- a/example/tests/test-common.sh
+++ b/example/tests/test-common.sh
@@ -298,9 +298,10 @@ EOF
 
 # touch_np_configmap <configmap_name> - annotate the ConfigMap to fire a
 # watch event and force a reconcile pass. The operator has NO timer-driven
-# requeue: "periodic" NetworkPolicy reconciliation (which refreshes PR state
-# from GitHub) only runs inside an event-triggered reconcile once
-# reconciliationInterval has elapsed. After out-of-band GitHub changes (a PR
+# requeue: "periodic" NetworkPolicy reconciliation (drift/template/stale
+# checks on pr-merged entries only — it does NOT refresh pr-pending entries
+# from GitHub; no such path exists yet) only runs inside an event-triggered
+# reconcile once reconciliationInterval has elapsed. After out-of-band GitHub changes (a PR
 # merged by a test, a template edited) nothing fires a Kubernetes event, so
 # the PermissionBinder status never refreshes on its own - verified live in
 # issue #59 (lastNetworkPolicyReconciliation frozen despite a 10s interval).

--- a/example/tests/test-implementations/test-44-networkpolicy---variant-a-new-file-from-template.sh
+++ b/example/tests/test-implementations/test-44-networkpolicy---variant-a-new-file-from-template.sh
@@ -1,10 +1,24 @@
 #!/bin/bash
 # Test 44: NetworkPolicy - Variant A (New File from Template)
+#
+# Self-contained under the first-owner-wins ownership gate (issues #45/#59):
+# provisions its OWN ConfigMap resolving to DEDICATED namespaces instead of
+# reusing the runner's baseline ConfigMap (permission-config), which is already
+# owned by the baseline PermissionBinder - a second CR referencing it gets the
+# whitelist's namespaces split deterministically between the two CRs and its
+# PRs for the lost namespaces never materialize.
 # Source common functions (SCRIPT_DIR should be set by parent script)
 if [ -z "$SCRIPT_DIR" ]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fi
 source "$SCRIPT_DIR/test-common.sh"
+
+BINDER_NAME="test-permissionbinder-networkpolicy"
+CONFIGMAP_NAME="np-test-config-44"
+# Dedicated namespaces (prefix empty in legacy single-instance mode; names
+# contain "test-" so both cleanup sweeps catch them)
+NS_ENGINEER="${TEST_NS_PREFIX}np-test-44"
+NS_VIEWER="${TEST_NS_PREFIX}np-test-44-2"
 
 # ============================================================================
 # ============================================================================
@@ -28,14 +42,14 @@ else
     fi
 fi
 
-# Setup: Create PermissionBinder with NetworkPolicy enabled
-if ! kubectl_retry kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE >/dev/null 2>&1; then
+# Setup: Create PermissionBinder with NetworkPolicy enabled (own ConfigMap)
+if ! kubectl_retry kubectl get permissionbinder "$BINDER_NAME" -n $NAMESPACE >/dev/null 2>&1; then
     info_log "Creating PermissionBinder with NetworkPolicy enabled"
     cat <<EOF | kubectl apply -f - >/dev/null 2>&1
 apiVersion: permission.permission-binder.io/v1
 kind: PermissionBinder
 metadata:
-  name: test-permissionbinder-networkpolicy
+  name: $BINDER_NAME
   namespace: $NAMESPACE
 spec:
   prefixes:
@@ -43,7 +57,7 @@ spec:
   roleMapping:
     engineer: "edit"
     viewer: "view"
-  configMapName: "permission-config"
+  configMapName: "$CONFIGMAP_NAME"
   configMapNamespace: "$NAMESPACE"
   networkPolicy:
     enabled: true
@@ -71,18 +85,11 @@ spec:
 EOF
 fi
 
-# Update ConfigMap with test namespaces
-cat <<EOF | kubectl apply -f - >/dev/null 2>&1
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: permission-config
-  namespace: $NAMESPACE
-data:
-  whitelist.txt: |
-    CN=COMPANY-K8S-test-app-engineer,OU=Openshift,DC=example,DC=com
-    CN=COMPANY-K8S-test-app-2-viewer,OU=Openshift,DC=example,DC=com
-EOF
+# Own ConfigMap -> this CR is the first (and only) owner of its namespaces
+if ! create_np_test_configmap "$CONFIGMAP_NAME" "$NS_ENGINEER" "$NS_VIEWER:viewer"; then
+    fail_test "Could not create test ConfigMap $CONFIGMAP_NAME"
+    exit 1
+fi
 
 # Wait for reconciliation (reduced from 10s to 5s - operator processes quickly)
 info_log "Waiting for PermissionBinder to process ConfigMap (5s)"
@@ -94,7 +101,7 @@ WAITED=0
 POLL_INTERVAL=2  # Faster polling: 2 seconds instead of 5
 NAMESPACES_FOUND=""
 while [ $WAITED -lt $MAX_WAIT ]; do
-    NAMESPACES_FOUND=$(kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE -o jsonpath='{.status.networkPolicies[*].namespace}' 2>/dev/null || echo "")
+    NAMESPACES_FOUND=$(kubectl get permissionbinder $BINDER_NAME -n $NAMESPACE -o jsonpath='{.status.networkPolicies[*].namespace}' 2>/dev/null || echo "")
     if [ -n "$NAMESPACES_FOUND" ] && [ "$NAMESPACES_FOUND" != "" ]; then
         break
     fi
@@ -110,11 +117,11 @@ fi
 
 # ============================================================================
 # VERIFICATION: Check PRs for ALL namespaces created by this test
-# Test creates ConfigMap with test-app and test-app-2, so we need to verify both
+# Test creates ConfigMap with $NS_ENGINEER and $NS_VIEWER, so we need to verify both
 # ============================================================================
 
 GITHUB_REPO="lukasz-bielinski/tests-network-policies"
-TEST_NAMESPACES=("test-app" "test-app-2")
+TEST_NAMESPACES=("$NS_ENGINEER" "$NS_VIEWER")
 PR_VERIFICATION_FAILED=0
 
 # Function to verify PR for a namespace
@@ -128,11 +135,11 @@ verify_pr_for_namespace() {
     
     # Wait for PR to be created and get PR number from status
     info_log "Waiting for PR to be created for $namespace (polling every 2s, up to 120s)..."
-    pr_number=$(wait_for_pr_in_status "test-permissionbinder-networkpolicy" "$namespace" 120)
+    pr_number=$(wait_for_pr_in_status "$BINDER_NAME" "$namespace" 120)
     
     # If PR number not found, check if PR state indicates it was merged (may need to get PR from GitHub)
     if [ -z "$pr_number" ] || [ "$pr_number" == "" ]; then
-        local pr_state=$(kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE -o jsonpath="{.status.networkPolicies[?(@.namespace==\"$namespace\")].state}" 2>/dev/null || echo "")
+        local pr_state=$(kubectl get permissionbinder $BINDER_NAME -n $NAMESPACE -o jsonpath="{.status.networkPolicies[?(@.namespace==\"$namespace\")].state}" 2>/dev/null || echo "")
         if [ "$pr_state" == "pr-merged" ] || [ "$pr_state" == "pr-pending" ]; then
             info_log "PR state found: $pr_state, but PR number missing. Checking GitHub for recent PRs..."
             if command -v gh &> /dev/null; then
@@ -154,7 +161,7 @@ verify_pr_for_namespace() {
     pass_test "PR number found for $namespace: $pr_number"
     
     # Get PR details from status
-    local pr_details=$(get_pr_from_status "test-permissionbinder-networkpolicy" "$namespace")
+    local pr_details=$(get_pr_from_status "$BINDER_NAME" "$namespace")
     local pr_num pr_url pr_branch pr_state
     IFS='|' read -r pr_num pr_url pr_branch pr_state <<< "$pr_details"
     
@@ -191,10 +198,10 @@ verify_pr_for_namespace() {
             PR_VERIFICATION_FAILED=1
         fi
         
-        # Verify PR contains expected files (only for test-app, as it's the primary test case)
-        if [ "$namespace" == "test-app" ]; then
+        # Verify PR contains expected files (only for $NS_ENGINEER, as it's the primary test case)
+        if [ "$namespace" == "$NS_ENGINEER" ]; then
             info_log "Verifying PR files..."
-            local expected_files="networkpolicies/DEV-cluster/test-app/test-app-deny-all-ingress.yaml networkpolicies/DEV-cluster/kustomization.yaml"
+            local expected_files="networkpolicies/DEV-cluster/$NS_ENGINEER/$NS_ENGINEER-deny-all-ingress.yaml networkpolicies/DEV-cluster/kustomization.yaml"
             if verify_pr_files "$GITHUB_REPO" "$pr_number" "$expected_files"; then
                 pass_test "PR contains expected NetworkPolicy files"
             else
@@ -234,7 +241,7 @@ verify_pr_for_namespace() {
     fi
     
     # Verify PR state in PermissionBinder status
-    local namespace_state=$(kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE -o jsonpath="{.status.networkPolicies[?(@.namespace==\"$namespace\")].state}" 2>/dev/null || echo "")
+    local namespace_state=$(kubectl get permissionbinder $BINDER_NAME -n $NAMESPACE -o jsonpath="{.status.networkPolicies[?(@.namespace==\"$namespace\")].state}" 2>/dev/null || echo "")
     if [ -n "$namespace_state" ]; then
         case "$namespace_state" in
             "pr-created"|"pr-pending"|"pr-merged")
@@ -261,7 +268,7 @@ done
 # ============================================================================
 # CLEANUP: Remove PRs and branches from GitHub (test isolation)
 # IMPORTANT: Cleanup is done AFTER all GitHub verifications are complete
-# IMPORTANT: Cleanup ALL namespaces from ConfigMap (test-app and test-app-2)
+# IMPORTANT: Cleanup ALL namespaces from ConfigMap ($NS_ENGINEER and $NS_VIEWER)
 # ============================================================================
 info_log "=========================================="
 info_log "All PR verifications completed. Starting cleanup..."
@@ -270,7 +277,7 @@ info_log "=========================================="
 # Cleanup all test namespaces (regardless of verification result)
 for test_ns in "${TEST_NAMESPACES[@]}"; do
     info_log "Cleaning up $test_ns namespace..."
-    cleanup_networkpolicy_test_artifacts "test-permissionbinder-networkpolicy" "$test_ns" "$GITHUB_REPO"
+    cleanup_networkpolicy_test_artifacts "$BINDER_NAME" "$test_ns" "$GITHUB_REPO"
 done
 
 # Final cleanup: Remove entire cluster directory

--- a/example/tests/test-implementations/test-45-networkpolicy---variant-b-backup-existing-template-based-policy.sh
+++ b/example/tests/test-implementations/test-45-networkpolicy---variant-b-backup-existing-template-based-policy.sh
@@ -1,10 +1,20 @@
 #!/bin/bash
 # Test 45: Networkpolicy   Variant B Backup Existing Template Based Policy
+#
+# Self-contained under the first-owner-wins ownership gate (issues #45/#59):
+# own ConfigMap + dedicated namespace instead of the shared permission-config
+# ConfigMap already owned by the runner's baseline PermissionBinder.
 # Source common functions
 if [ -z "$SCRIPT_DIR" ]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fi
 source "$SCRIPT_DIR/test-common.sh"
+
+BINDER_NAME="test-permissionbinder-networkpolicy"
+CONFIGMAP_NAME="np-test-config-45"
+# Dedicated namespace (prefix empty in legacy single-instance mode; name
+# contains "test-" so both cleanup sweeps catch it)
+BACKUP_NS="${TEST_NS_PREFIX}np-test-45-backup"
 
 # ============================================================================
 # ============================================================================
@@ -29,13 +39,13 @@ else
 fi
 
 # Setup: Create PermissionBinder with NetworkPolicy enabled and backupExisting: true
-if ! kubectl_retry kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE >/dev/null 2>&1; then
+if ! kubectl_retry kubectl get permissionbinder $BINDER_NAME -n $NAMESPACE >/dev/null 2>&1; then
     info_log "Creating PermissionBinder with NetworkPolicy enabled and backupExisting: true"
     cat <<EOF | kubectl apply -f - >/dev/null 2>&1
 apiVersion: permission.permission-binder.io/v1
 kind: PermissionBinder
 metadata:
-  name: test-permissionbinder-networkpolicy
+  name: $BINDER_NAME
   namespace: $NAMESPACE
 spec:
   prefixes:
@@ -43,7 +53,7 @@ spec:
   roleMapping:
     engineer: "edit"
     viewer: "view"
-  configMapName: "permission-config"
+  configMapName: "$CONFIGMAP_NAME"
   configMapNamespace: "$NAMESPACE"
   networkPolicy:
     enabled: true
@@ -72,8 +82,8 @@ EOF
 fi
 
 # Create namespace with existing NetworkPolicy matching template pattern
-if ! kubectl get namespace test-backup-ns >/dev/null 2>&1; then
-    kubectl create namespace test-backup-ns >/dev/null 2>&1
+if ! kubectl get namespace "$BACKUP_NS" >/dev/null 2>&1; then
+    kubectl create namespace "$BACKUP_NS" >/dev/null 2>&1
 fi
 
 # Create existing NetworkPolicy that matches template pattern
@@ -81,8 +91,8 @@ cat <<EOF | kubectl apply -f - >/dev/null 2>&1
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: test-backup-ns-deny-all-ingress
-  namespace: test-backup-ns
+  name: $BACKUP_NS-deny-all-ingress
+  namespace: $BACKUP_NS
   annotations:
     network-policy.permission-binder.io/template: "deny-all-ingress.yaml"
 spec:
@@ -92,35 +102,23 @@ spec:
   ingress: []
 EOF
 
-# Update ConfigMap to include test-backup-ns namespace
-cat <<EOF | kubectl apply -f - >/dev/null 2>&1
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: permission-config
-  namespace: $NAMESPACE
-data:
-  whitelist.txt: |
-    CN=COMPANY-K8S-test-app-engineer,OU=Openshift,DC=example,DC=com
-    CN=COMPANY-K8S-test-app-2-viewer,OU=Openshift,DC=example,DC=com
-    CN=COMPANY-K8S-test-backup-ns-engineer,OU=Openshift,DC=example,DC=com
-EOF
+# Own ConfigMap resolving to the dedicated backup namespace
+if ! create_np_test_configmap "$CONFIGMAP_NAME" "$BACKUP_NS"; then
+    fail_test "Could not create test ConfigMap $CONFIGMAP_NAME"
+    exit 1
+fi
 
 # Wait for reconciliation to process backup (increased to allow operator time to create PRs)
 info_log "Waiting for reconciliation to process backup (15s)"
 sleep 15
 
 # ============================================================================
-# VERIFICATION: Check PR for test-backup-ns namespace (main test objective)
-# NOTE: test-app and test-app-2 may be skipped by operator if they already have status
-#       from previous tests (operator optimization - skips already processed namespaces)
-#       The main objective of this test is to verify backup variant for test-backup-ns
+# VERIFICATION: Check PR for $BACKUP_NS namespace (main test objective)
 # ============================================================================
 
 GITHUB_REPO="lukasz-bielinski/tests-network-policies"
-# Main test objective: verify backup for test-backup-ns
-# Other namespaces (test-app, test-app-2) may be skipped if already processed
-MAIN_TEST_NAMESPACE="test-backup-ns"
+# Main test objective: verify backup for $BACKUP_NS
+MAIN_TEST_NAMESPACE="$BACKUP_NS"
 PR_VERIFICATION_FAILED=0
 
 # Function to verify PR for a namespace (reuse from test-44 pattern)
@@ -134,11 +132,11 @@ verify_pr_for_namespace() {
     
     # Wait for PR to be created and get PR number from status
     info_log "Waiting for PR to be created for $namespace (polling every 2s, up to 120s)..."
-    pr_number=$(wait_for_pr_in_status "test-permissionbinder-networkpolicy" "$namespace" 120)
+    pr_number=$(wait_for_pr_in_status "$BINDER_NAME" "$namespace" 120)
     
     # If PR number not found, check if PR state indicates it was merged (may need to get PR from GitHub)
     if [ -z "$pr_number" ] || [ "$pr_number" == "" ]; then
-        local pr_state=$(kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE -o jsonpath="{.status.networkPolicies[?(@.namespace==\"$namespace\")].state}" 2>/dev/null || echo "")
+        local pr_state=$(kubectl get permissionbinder $BINDER_NAME -n $NAMESPACE -o jsonpath="{.status.networkPolicies[?(@.namespace==\"$namespace\")].state}" 2>/dev/null || echo "")
         if [ "$pr_state" == "pr-merged" ] || [ "$pr_state" == "pr-pending" ]; then
             info_log "PR state found: $pr_state, but PR number missing. Checking GitHub for recent PRs..."
             if command -v gh &> /dev/null; then
@@ -159,7 +157,7 @@ verify_pr_for_namespace() {
     pass_test "PR number found for $namespace: $pr_number"
     
     # Get PR details from status
-    local pr_details=$(get_pr_from_status "test-permissionbinder-networkpolicy" "$namespace")
+    local pr_details=$(get_pr_from_status "$BINDER_NAME" "$namespace")
     local pr_num pr_url pr_branch pr_state
     IFS='|' read -r pr_num pr_url pr_branch pr_state <<< "$pr_details"
     
@@ -198,8 +196,8 @@ verify_pr_for_namespace() {
             PR_VERIFICATION_FAILED=1
         fi
         
-        # Special verification for test-backup-ns (backup variant)
-        if [ "$namespace" == "test-backup-ns" ]; then
+        # Special verification for $BACKUP_NS (backup variant)
+        if [ "$namespace" == "$BACKUP_NS" ]; then
             if echo "$pr_title" | grep -qi "backup"; then
                 pass_test "PR title indicates backup variant"
             else
@@ -208,7 +206,7 @@ verify_pr_for_namespace() {
             
             # Verify PR contains backup files
             info_log "Verifying backup PR files..."
-            local expected_files="networkpolicies/DEV-cluster/test-backup-ns/test-backup-ns-deny-all-ingress.yaml networkpolicies/DEV-cluster/kustomization.yaml"
+            local expected_files="networkpolicies/DEV-cluster/$BACKUP_NS/$BACKUP_NS-deny-all-ingress.yaml networkpolicies/DEV-cluster/kustomization.yaml"
             if verify_pr_files "$GITHUB_REPO" "$pr_number" "$expected_files"; then
                 pass_test "Backup PR contains expected files"
             else
@@ -223,7 +221,7 @@ verify_pr_for_namespace() {
     fi
     
     # Verify PR state in PermissionBinder status
-    local namespace_state=$(kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE -o jsonpath="{.status.networkPolicies[?(@.namespace==\"$namespace\")].state}" 2>/dev/null || echo "")
+    local namespace_state=$(kubectl get permissionbinder $BINDER_NAME -n $NAMESPACE -o jsonpath="{.status.networkPolicies[?(@.namespace==\"$namespace\")].state}" 2>/dev/null || echo "")
     if [ -n "$namespace_state" ]; then
         case "$namespace_state" in
             "pr-created"|"pr-pending"|"pr-merged")
@@ -240,40 +238,22 @@ verify_pr_for_namespace() {
     return 0
 }
 
-# Verify PR for main test namespace (test-backup-ns)
+# Verify PR for main test namespace ($BACKUP_NS)
 # This is the main objective: verify backup variant works
 if ! verify_pr_for_namespace "$MAIN_TEST_NAMESPACE"; then
     PR_VERIFICATION_FAILED=1
 fi
 
-# Optional: Check if other namespaces were processed or skipped
-# (operator may skip them if they already have status from previous tests)
-info_log "Checking status of other namespaces (may be skipped if already processed)..."
-for ns in "test-app" "test-app-2"; do
-    NS_STATE=$(kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE -o jsonpath="{.status.networkPolicies[?(@.namespace==\"$ns\")].state}" 2>/dev/null || echo "")
-    if [ -n "$NS_STATE" ]; then
-        info_log "Namespace $ns has state: $NS_STATE (already processed - operator optimization)"
-    else
-        info_log "Namespace $ns not in status (may be skipped by operator if already processed)"
-    fi
-done
-
 # ============================================================================
 # CLEANUP: Remove PRs and branches from GitHub (test isolation)
 # IMPORTANT: Cleanup is done AFTER all GitHub verifications are complete
-# IMPORTANT: Cleanup ALL namespaces from ConfigMap and remove entire cluster directory
 # ============================================================================
 info_log "=========================================="
 info_log "All PR verifications completed. Starting cleanup..."
 info_log "=========================================="
 
-# Cleanup: Clean up all namespaces that might have been processed
-# (including test-app and test-app-2 if they were processed)
 info_log "Cleaning up test namespaces..."
-cleanup_networkpolicy_test_artifacts "test-permissionbinder-networkpolicy" "$MAIN_TEST_NAMESPACE" "$GITHUB_REPO"
-# Also cleanup test-app and test-app-2 if they exist (may have been processed)
-cleanup_networkpolicy_test_artifacts "test-permissionbinder-networkpolicy" "test-app" "$GITHUB_REPO" 2>/dev/null || true
-cleanup_networkpolicy_test_artifacts "test-permissionbinder-networkpolicy" "test-app-2" "$GITHUB_REPO" 2>/dev/null || true
+cleanup_networkpolicy_test_artifacts "$BINDER_NAME" "$MAIN_TEST_NAMESPACE" "$GITHUB_REPO"
 
 # Final cleanup: Remove entire cluster directory
 info_log "Final cleanup: Removing entire DEV-cluster directory..."
@@ -286,8 +266,8 @@ if [ $PR_VERIFICATION_FAILED -eq 1 ]; then
 fi
 
 # Cleanup Kubernetes resources (always, regardless of PR status)
-kubectl delete networkpolicy test-backup-ns-deny-all-ingress -n test-backup-ns --ignore-not-found=true >/dev/null 2>&1
-kubectl delete namespace test-backup-ns --ignore-not-found=true >/dev/null 2>&1
+kubectl delete networkpolicy $BACKUP_NS-deny-all-ingress -n $BACKUP_NS --ignore-not-found=true >/dev/null 2>&1
+kubectl delete namespace $BACKUP_NS --ignore-not-found=true >/dev/null 2>&1
 
 echo ""
 

--- a/example/tests/test-implementations/test-46-networkpolicy---drift-detection.sh
+++ b/example/tests/test-implementations/test-46-networkpolicy---drift-detection.sh
@@ -1,10 +1,23 @@
 #!/bin/bash
 # Test 46: Networkpolicy   Drift Detection
+#
+# Self-contained under the first-owner-wins ownership gate (issues #45/#59):
+# provisions its OWN PermissionBinder + ConfigMap resolving to a DEDICATED
+# namespace. Previously this test only read the PermissionBinder created by
+# earlier NP tests, which does not exist under full isolation (per-test
+# cleanup runs before every test) - all assertions were vacuous.
 # Source common functions
 if [ -z "$SCRIPT_DIR" ]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fi
 source "$SCRIPT_DIR/test-common.sh"
+
+BINDER_NAME="test-permissionbinder-networkpolicy-drift"
+CONFIGMAP_NAME="np-test-config-46"
+# Dedicated namespace (prefix empty in legacy single-instance mode; name
+# contains "test-" so both cleanup sweeps catch it)
+TEST_NAMESPACE="${TEST_NS_PREFIX}np-test-46"
+GITHUB_REPO="lukasz-bielinski/tests-network-policies"
 
 # ============================================================================
 # ============================================================================
@@ -12,15 +25,83 @@ echo ""
 echo "Test 46: NetworkPolicy - Drift Detection"
 echo "-----------------------------------------"
 
-# Wait for periodic reconciliation interval
-# Note: This test requires periodic reconciliation to run
-# In real scenario, would wait for reconciliationInterval (1h)
+cleanup_resources() {
+    # Delete the PB FIRST: with a 10s reconciliationInterval the operator
+    # could otherwise recreate the PR between artifact cleanup and PB removal.
+    # cleanup_networkpolicy_test_artifacts falls back to a branch-name lookup
+    # on GitHub when the PB status is gone.
+    kubectl delete permissionbinder "$BINDER_NAME" -n "$NAMESPACE" --ignore-not-found=true >/dev/null 2>&1
+    kubectl delete configmap "$CONFIGMAP_NAME" -n "$NAMESPACE" --ignore-not-found=true >/dev/null 2>&1
+    cleanup_networkpolicy_test_artifacts "$BINDER_NAME" "$TEST_NAMESPACE" "$GITHUB_REPO" 2>/dev/null || true
+}
+
+trap cleanup_resources EXIT
+
+# ----------------------------------------------------------------------------
+# 1. Ensure GitHub credentials Secret exists
+# ----------------------------------------------------------------------------
+CREDENTIALS_FILE="$SCRIPT_DIR/../../temp/github-gitops-credentials-secret.yaml"
+if [ ! -f "$CREDENTIALS_FILE" ]; then
+    fail_test "GitHub credentials file not found: $CREDENTIALS_FILE"
+    exit 1
+fi
+
+if ! kubectl_retry kubectl get secret github-gitops-credentials -n "$NAMESPACE" >/dev/null 2>&1; then
+    info_log "Creating GitHub credentials Secret from $CREDENTIALS_FILE"
+    sed "s/namespace: permissions-binder-operator/namespace: $NAMESPACE/" "$CREDENTIALS_FILE" | kubectl apply -f - >/dev/null 2>&1
+fi
+
+# ----------------------------------------------------------------------------
+# 2. Create PermissionBinder with a short reconciliation interval so the
+#    periodic (drift-detection) reconciliation actually runs during the test
+# ----------------------------------------------------------------------------
+info_log "Creating PermissionBinder $BINDER_NAME with reconciliationInterval=10s"
+cat <<EOF | kubectl apply -f - >/dev/null 2>&1
+apiVersion: permission.permission-binder.io/v1
+kind: PermissionBinder
+metadata:
+  name: $BINDER_NAME
+  namespace: $NAMESPACE
+spec:
+  prefixes:
+    - "COMPANY-K8S"
+  roleMapping:
+    engineer: "edit"
+    viewer: "view"
+  configMapName: "$CONFIGMAP_NAME"
+  configMapNamespace: "$NAMESPACE"
+  networkPolicy:
+    enabled: true
+    gitRepository:
+      provider: "github"
+      url: "https://github.com/lukasz-bielinski/tests-network-policies.git"
+      baseBranch: "main"
+      clusterName: "DEV-cluster"
+      credentialsSecretRef:
+        name: "github-gitops-credentials"
+        namespace: "$NAMESPACE"
+    templateDir: "networkpolicies/templates"
+    autoMerge:
+      enabled: false
+    backupExisting: true
+    reconciliationInterval: "10s"
+EOF
+
+# Own ConfigMap -> this CR is the first (and only) owner of $TEST_NAMESPACE
+if ! create_np_test_configmap "$CONFIGMAP_NAME" "$TEST_NAMESPACE"; then
+    fail_test "Could not create test ConfigMap $CONFIGMAP_NAME"
+    exit 1
+fi
+
+# ----------------------------------------------------------------------------
+# 3. Wait for the periodic reconciliation timestamp
+# ----------------------------------------------------------------------------
 info_log "Waiting for periodic reconciliation (up to 90s)"
 MAX_WAIT=90
 WAITED=0
 RECONCILIATION_TIME=""
 while [ $WAITED -lt $MAX_WAIT ]; do
-    RECONCILIATION_TIME=$(kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE -o jsonpath='{.status.lastNetworkPolicyReconciliation}' 2>/dev/null || echo "")
+    RECONCILIATION_TIME=$(kubectl get permissionbinder "$BINDER_NAME" -n $NAMESPACE -o jsonpath='{.status.lastNetworkPolicyReconciliation}' 2>/dev/null || echo "")
     if [ -n "$RECONCILIATION_TIME" ] && [ "$RECONCILIATION_TIME" != "" ]; then
         break
     fi
@@ -31,35 +112,24 @@ done
 if [ -n "$RECONCILIATION_TIME" ] && [ "$RECONCILIATION_TIME" != "" ]; then
     pass_test "Periodic reconciliation timestamp found: $RECONCILIATION_TIME"
 else
-    info_log "Periodic reconciliation timestamp not yet available (may need to wait for reconciliationInterval: 1h)"
+    fail_test "Periodic reconciliation timestamp not set within ${MAX_WAIT}s (reconciliationInterval: 10s)"
 fi
 
 # ============================================================================
-# VERIFICATION: Check PRs for ALL namespaces in PermissionBinder status
-# This test doesn't create new PRs, but should verify existing ones
+# VERIFICATION: Check namespaces tracked in PermissionBinder status
+# This test verifies the periodic reconciliation loop, not PR creation;
+# the PR created for $TEST_NAMESPACE is cleaned up by the EXIT trap.
 # ============================================================================
-GITHUB_REPO="lukasz-bielinski/tests-network-policies"
-
-# Get all namespaces with NetworkPolicy status
-ALL_NAMESPACES=$(kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE -o jsonpath='{.status.networkPolicies[*].namespace}' 2>/dev/null || echo "")
+ALL_NAMESPACES=$(kubectl get permissionbinder "$BINDER_NAME" -n $NAMESPACE -o jsonpath='{.status.networkPolicies[*].namespace}' 2>/dev/null || echo "")
 
 if [ -n "$ALL_NAMESPACES" ] && [ "$ALL_NAMESPACES" != "" ]; then
     info_log "Found namespaces with NetworkPolicy status: $ALL_NAMESPACES"
     info_log "Note: This test verifies periodic reconciliation, not PR creation"
 else
-    info_log "No namespaces found in NetworkPolicy status (may be normal if no PRs were created)"
+    info_log "No namespaces found in NetworkPolicy status (may be normal if no PRs were created yet)"
 fi
 
-# ============================================================================
-# CLEANUP: Remove PRs and branches from GitHub (test isolation)
-# IMPORTANT: Cleanup is done AFTER all verifications are complete
-# IMPORTANT: Removes entire cluster_name directory
-# ============================================================================
-info_log "=========================================="
-info_log "Starting cleanup..."
-info_log "=========================================="
-cleanup_all_networkpolicy_test_artifacts "test-permissionbinder-networkpolicy" "$GITHUB_REPO" "DEV-cluster"
-
+# Cleanup handled by trap
 echo ""
 
 # ============================================================================

--- a/example/tests/test-implementations/test-47-networkpolicy---exclude-lists.sh
+++ b/example/tests/test-implementations/test-47-networkpolicy---exclude-lists.sh
@@ -1,10 +1,23 @@
 #!/bin/bash
 # Test 47: Networkpolicy   Exclude Lists
+#
+# Self-contained under the first-owner-wins ownership gate (issues #45/#59):
+# provisions its OWN PermissionBinder + ConfigMap instead of mutating the
+# shared permission-config ConfigMap (owned by the runner's baseline CR, which
+# would create unprefixed orphan namespaces) and reading a PermissionBinder
+# that does not exist under full isolation.
 # Source common functions
 if [ -z "$SCRIPT_DIR" ]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fi
 source "$SCRIPT_DIR/test-common.sh"
+
+BINDER_NAME="test-permissionbinder-networkpolicy-exclude"
+CONFIGMAP_NAME="np-test-config-47"
+# Dedicated namespace (prefix empty in legacy single-instance mode; name
+# contains "test-" so both cleanup sweeps catch it)
+TEST_NAMESPACE="${TEST_NS_PREFIX}np-test-47"
+GITHUB_REPO="lukasz-bielinski/tests-network-policies"
 
 # ============================================================================
 # ============================================================================
@@ -12,33 +25,111 @@ echo ""
 echo "Test 47: NetworkPolicy - Exclude Lists"
 echo "---------------------------------------"
 
-# Add excluded namespace to ConfigMap
+cleanup_resources() {
+    kubectl delete permissionbinder "$BINDER_NAME" -n "$NAMESPACE" --ignore-not-found=true >/dev/null 2>&1
+    kubectl delete configmap "$CONFIGMAP_NAME" -n "$NAMESPACE" --ignore-not-found=true >/dev/null 2>&1
+    cleanup_networkpolicy_test_artifacts "$BINDER_NAME" "$TEST_NAMESPACE" "$GITHUB_REPO" 2>/dev/null || true
+}
+
+trap cleanup_resources EXIT
+
+# ----------------------------------------------------------------------------
+# 1. Ensure GitHub credentials Secret exists
+# ----------------------------------------------------------------------------
+CREDENTIALS_FILE="$SCRIPT_DIR/../../temp/github-gitops-credentials-secret.yaml"
+if [ ! -f "$CREDENTIALS_FILE" ]; then
+    fail_test "GitHub credentials file not found: $CREDENTIALS_FILE"
+    exit 1
+fi
+
+if ! kubectl_retry kubectl get secret github-gitops-credentials -n "$NAMESPACE" >/dev/null 2>&1; then
+    info_log "Creating GitHub credentials Secret from $CREDENTIALS_FILE"
+    sed "s/namespace: permissions-binder-operator/namespace: $NAMESPACE/" "$CREDENTIALS_FILE" | kubectl apply -f - >/dev/null 2>&1
+fi
+
+# ----------------------------------------------------------------------------
+# 2. Create PermissionBinder with kube-system in the NP exclude list
+# ----------------------------------------------------------------------------
+info_log "Creating PermissionBinder $BINDER_NAME with excludeNamespaces"
 cat <<EOF | kubectl apply -f - >/dev/null 2>&1
-apiVersion: v1
-kind: ConfigMap
+apiVersion: permission.permission-binder.io/v1
+kind: PermissionBinder
 metadata:
-  name: permission-config
+  name: $BINDER_NAME
   namespace: $NAMESPACE
-data:
-  whitelist.txt: |
-    CN=COMPANY-K8S-test-app-engineer,OU=Openshift,DC=example,DC=com
-    CN=COMPANY-K8S-test-app-2-viewer,OU=Openshift,DC=example,DC=com
-    CN=COMPANY-K8S-kube-system-engineer,OU=Openshift,DC=example,DC=com
+spec:
+  prefixes:
+    - "COMPANY-K8S"
+  roleMapping:
+    engineer: "edit"
+    viewer: "view"
+  configMapName: "$CONFIGMAP_NAME"
+  configMapNamespace: "$NAMESPACE"
+  networkPolicy:
+    enabled: true
+    gitRepository:
+      provider: "github"
+      url: "https://github.com/lukasz-bielinski/tests-network-policies.git"
+      baseBranch: "main"
+      clusterName: "DEV-cluster"
+      credentialsSecretRef:
+        name: "github-gitops-credentials"
+        namespace: "$NAMESPACE"
+    templateDir: "networkpolicies/templates"
+    autoMerge:
+      enabled: false
+    excludeNamespaces:
+      explicit:
+        - "kube-system"
+        - "kube-public"
+      patterns:
+        - "^kube-.*"
+        - "^openshift-.*"
+    backupExisting: true
+    reconciliationInterval: "1h"
 EOF
+
+# Own ConfigMap: one dedicated namespace + an excluded one (kube-system)
+if ! create_np_test_configmap "$CONFIGMAP_NAME" "$TEST_NAMESPACE" "kube-system"; then
+    fail_test "Could not create test ConfigMap $CONFIGMAP_NAME"
+    exit 1
+fi
 
 # Wait for reconciliation
 info_log "Waiting for reconciliation (10s)"
 sleep 10
 
-# Verify kube-system is excluded from NetworkPolicy processing
-ALL_NAMESPACES=$(kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE -o jsonpath='{.status.networkPolicies[*].namespace}' 2>/dev/null || echo "")
-EXCLUDED_FOUND=false
-for ns in $ALL_NAMESPACES; do
-    if [ "$ns" == "kube-system" ]; then
-        EXCLUDED_FOUND=true
+# ----------------------------------------------------------------------------
+# 3. Verify the non-excluded namespace IS processed and kube-system is NOT
+# ----------------------------------------------------------------------------
+MAX_WAIT=60
+WAITED=0
+ALL_NAMESPACES=""
+while [ $WAITED -lt $MAX_WAIT ]; do
+    ALL_NAMESPACES=$(kubectl get permissionbinder "$BINDER_NAME" -n $NAMESPACE -o jsonpath='{.status.networkPolicies[*].namespace}' 2>/dev/null || echo "")
+    if [ -n "$ALL_NAMESPACES" ]; then
         break
     fi
+    sleep 5
+    WAITED=$((WAITED + 5))
 done
+
+INCLUDED_FOUND=false
+EXCLUDED_FOUND=false
+for ns in $ALL_NAMESPACES; do
+    if [ "$ns" == "$TEST_NAMESPACE" ]; then
+        INCLUDED_FOUND=true
+    fi
+    if [ "$ns" == "kube-system" ]; then
+        EXCLUDED_FOUND=true
+    fi
+done
+
+if [ "$INCLUDED_FOUND" == "true" ]; then
+    pass_test "Non-excluded namespace $TEST_NAMESPACE is processed for NetworkPolicy"
+else
+    fail_test "Non-excluded namespace $TEST_NAMESPACE not found in NetworkPolicy status after ${MAX_WAIT}s"
+fi
 
 if [ "$EXCLUDED_FOUND" == "false" ]; then
     pass_test "kube-system is correctly excluded from NetworkPolicy processing"
@@ -46,32 +137,18 @@ else
     fail_test "kube-system should be excluded but was found in NetworkPolicy status"
 fi
 
-# ============================================================================
-# VERIFICATION: Check PRs for ALL namespaces in PermissionBinder status
-# Test creates ConfigMap with test-app, test-app-2 (kube-system is excluded)
-# ============================================================================
-GITHUB_REPO="lukasz-bielinski/tests-network-policies"
-TEST_NAMESPACES=("test-app" "test-app-2")  # kube-system is excluded, so no PR should be created
-
-info_log "Verifying PRs for test namespaces (excluding kube-system)..."
-for test_ns in "${TEST_NAMESPACES[@]}"; do
-    # Check if namespace has PR status (may or may not have PR, depending on previous tests)
-    NS_STATE=$(kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE -o jsonpath="{.status.networkPolicies[?(@.namespace==\"$test_ns\")].state}" 2>/dev/null || echo "")
-    if [ -n "$NS_STATE" ]; then
-        info_log "Namespace $test_ns has state: $NS_STATE"
-    fi
-done
+# Wait for the PR to be recorded before finishing so the EXIT-trap cleanup
+# can find and remove it (avoids leaking an in-flight PR/branch).
+PR_NUMBER=$(wait_for_pr_in_status "$BINDER_NAME" "$TEST_NAMESPACE" 120)
+if [ -n "$PR_NUMBER" ]; then
+    info_log "PR recorded for $TEST_NAMESPACE (number: $PR_NUMBER); cleanup will remove it"
+else
+    info_log "⚠️  PR not recorded for $TEST_NAMESPACE within 120s (cleanup falls back to branch lookup)"
+fi
 
 # ============================================================================
-# CLEANUP: Remove PRs and branches from GitHub (test isolation)
-# IMPORTANT: Cleanup is done AFTER all verifications are complete
-# IMPORTANT: Removes entire cluster_name directory
+# CLEANUP: handled by trap (PR/branch/files for $TEST_NAMESPACE)
 # ============================================================================
-info_log "=========================================="
-info_log "Starting cleanup..."
-info_log "=========================================="
-cleanup_all_networkpolicy_test_artifacts "test-permissionbinder-networkpolicy" "$GITHUB_REPO" "DEV-cluster"
-
 echo ""
 
 # ============================================================================

--- a/example/tests/test-implementations/test-48-networkpolicy---stale-pr-detection.sh
+++ b/example/tests/test-implementations/test-48-networkpolicy---stale-pr-detection.sh
@@ -1,10 +1,23 @@
 #!/bin/bash
 # Test 48: Networkpolicy   Stale Pr Detection
+#
+# Self-contained under the first-owner-wins ownership gate (issues #45/#59):
+# provisions its OWN PermissionBinder + ConfigMap resolving to a DEDICATED
+# namespace. Previously this test only read the PermissionBinder created by
+# earlier NP tests, which does not exist under full isolation - all checks
+# were vacuous.
 # Source common functions
 if [ -z "$SCRIPT_DIR" ]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fi
 source "$SCRIPT_DIR/test-common.sh"
+
+BINDER_NAME="test-permissionbinder-networkpolicy-stale"
+CONFIGMAP_NAME="np-test-config-48"
+# Dedicated namespace (prefix empty in legacy single-instance mode; name
+# contains "test-" so both cleanup sweeps catch it)
+TEST_NAMESPACE="${TEST_NS_PREFIX}np-test-48"
+GITHUB_REPO="lukasz-bielinski/tests-network-policies"
 
 # ============================================================================
 # ============================================================================
@@ -12,9 +25,94 @@ echo ""
 echo "Test 48: NetworkPolicy - Stale PR Detection"
 echo "--------------------------------------------"
 
-# This test verifies that stale PR detection runs
-# In real scenario, would wait for stalePRThreshold
-ALL_STATES=$(kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE -o jsonpath='{.status.networkPolicies[*].state}' 2>/dev/null || echo "")
+cleanup_resources() {
+    # Delete the PB first so the operator cannot recreate the PR between
+    # artifact cleanup and PB removal (cleanup falls back to branch lookup).
+    kubectl delete permissionbinder "$BINDER_NAME" -n "$NAMESPACE" --ignore-not-found=true >/dev/null 2>&1
+    kubectl delete configmap "$CONFIGMAP_NAME" -n "$NAMESPACE" --ignore-not-found=true >/dev/null 2>&1
+    cleanup_networkpolicy_test_artifacts "$BINDER_NAME" "$TEST_NAMESPACE" "$GITHUB_REPO" 2>/dev/null || true
+}
+
+trap cleanup_resources EXIT
+
+# ----------------------------------------------------------------------------
+# 1. Ensure GitHub credentials Secret exists
+# ----------------------------------------------------------------------------
+CREDENTIALS_FILE="$SCRIPT_DIR/../../temp/github-gitops-credentials-secret.yaml"
+if [ ! -f "$CREDENTIALS_FILE" ]; then
+    fail_test "GitHub credentials file not found: $CREDENTIALS_FILE"
+    exit 1
+fi
+
+if ! kubectl_retry kubectl get secret github-gitops-credentials -n "$NAMESPACE" >/dev/null 2>&1; then
+    info_log "Creating GitHub credentials Secret from $CREDENTIALS_FILE"
+    sed "s/namespace: permissions-binder-operator/namespace: $NAMESPACE/" "$CREDENTIALS_FILE" | kubectl apply -f - >/dev/null 2>&1
+fi
+
+# ----------------------------------------------------------------------------
+# 2. Create PermissionBinder (auto-merge off so the PR stays open) + ConfigMap
+# ----------------------------------------------------------------------------
+info_log "Creating PermissionBinder $BINDER_NAME"
+cat <<EOF | kubectl apply -f - >/dev/null 2>&1
+apiVersion: permission.permission-binder.io/v1
+kind: PermissionBinder
+metadata:
+  name: $BINDER_NAME
+  namespace: $NAMESPACE
+spec:
+  prefixes:
+    - "COMPANY-K8S"
+  roleMapping:
+    engineer: "edit"
+    viewer: "view"
+  configMapName: "$CONFIGMAP_NAME"
+  configMapNamespace: "$NAMESPACE"
+  networkPolicy:
+    enabled: true
+    gitRepository:
+      provider: "github"
+      url: "https://github.com/lukasz-bielinski/tests-network-policies.git"
+      baseBranch: "main"
+      clusterName: "DEV-cluster"
+      credentialsSecretRef:
+        name: "github-gitops-credentials"
+        namespace: "$NAMESPACE"
+    templateDir: "networkpolicies/templates"
+    autoMerge:
+      enabled: false
+    backupExisting: true
+    reconciliationInterval: "10s"
+EOF
+
+# Own ConfigMap -> this CR is the first (and only) owner of $TEST_NAMESPACE
+if ! create_np_test_configmap "$CONFIGMAP_NAME" "$TEST_NAMESPACE"; then
+    fail_test "Could not create test ConfigMap $CONFIGMAP_NAME"
+    exit 1
+fi
+
+# ----------------------------------------------------------------------------
+# 3. Wait for the PR (an open PR is the precondition for staleness tracking)
+# ----------------------------------------------------------------------------
+PR_NUMBER=$(wait_for_pr_in_status "$BINDER_NAME" "$TEST_NAMESPACE" 150)
+if [ -z "$PR_NUMBER" ]; then
+    fail_test "PR not created for namespace $TEST_NAMESPACE within 150s"
+    exit 1
+fi
+pass_test "PR created for $TEST_NAMESPACE (number: $PR_NUMBER)"
+
+# Verify the open PR carries a CreatedAt timestamp (input for stale detection)
+CREATED_AT=$(kubectl get permissionbinder "$BINDER_NAME" -n $NAMESPACE -o jsonpath='{.status.networkPolicies[?(@.namespace=="'$TEST_NAMESPACE'")].createdAt}' 2>/dev/null || echo "")
+if [ -n "$CREATED_AT" ]; then
+    pass_test "Open PR has CreatedAt timestamp for staleness tracking: $CREATED_AT"
+else
+    info_log "⚠️  CreatedAt timestamp not populated for $TEST_NAMESPACE"
+fi
+
+# ----------------------------------------------------------------------------
+# 4. Check for stale-PR state (informational: the freshly created PR only
+#    becomes pr-stale after stalePRThreshold, far beyond this test's window)
+# ----------------------------------------------------------------------------
+ALL_STATES=$(kubectl get permissionbinder "$BINDER_NAME" -n $NAMESPACE -o jsonpath='{.status.networkPolicies[*].state}' 2>/dev/null || echo "")
 STALE_FOUND=false
 for state in $ALL_STATES; do
     if [ "$state" == "pr-stale" ]; then
@@ -25,46 +123,24 @@ done
 
 if [ "$STALE_FOUND" == "true" ]; then
     # Verify CreatedAt timestamp exists for stale PR
-    STALE_CREATED_AT=$(kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE -o jsonpath='{.status.networkPolicies[?(@.state=="pr-stale")].createdAt}' 2>/dev/null || echo "")
+    STALE_CREATED_AT=$(kubectl get permissionbinder "$BINDER_NAME" -n $NAMESPACE -o jsonpath='{.status.networkPolicies[?(@.state=="pr-stale")].createdAt}' 2>/dev/null || echo "")
     if [ -n "$STALE_CREATED_AT" ] && [ "$STALE_CREATED_AT" != "" ]; then
         pass_test "Stale PR detected with CreatedAt timestamp: $STALE_CREATED_AT"
     else
         fail_test "Stale PR detected but CreatedAt timestamp missing"
     fi
 else
-    info_log "No stale PRs detected (may need to wait for stalePRThreshold)"
+    info_log "No stale PRs detected (expected: stalePRThreshold far exceeds test duration)"
 fi
 
-# ============================================================================
-# VERIFICATION: Check PRs for ALL namespaces in PermissionBinder status
-# This test verifies stale PR detection, should check all existing PRs
-# ============================================================================
-GITHUB_REPO="lukasz-bielinski/tests-network-policies"
+# Log PR states for all tracked namespaces
+ALL_NAMESPACES=$(kubectl get permissionbinder "$BINDER_NAME" -n $NAMESPACE -o jsonpath='{.status.networkPolicies[*].namespace}' 2>/dev/null || echo "")
+for ns in $ALL_NAMESPACES; do
+    NS_STATE=$(kubectl get permissionbinder "$BINDER_NAME" -n $NAMESPACE -o jsonpath="{.status.networkPolicies[?(@.namespace==\"$ns\")].state}" 2>/dev/null || echo "")
+    info_log "  Namespace $ns: state=$NS_STATE"
+done
 
-# Get all namespaces with NetworkPolicy status
-ALL_NAMESPACES=$(kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE -o jsonpath='{.status.networkPolicies[*].namespace}' 2>/dev/null || echo "")
-
-if [ -n "$ALL_NAMESPACES" ] && [ "$ALL_NAMESPACES" != "" ]; then
-    info_log "Found namespaces with NetworkPolicy status: $ALL_NAMESPACES"
-    info_log "Verifying PR states for all namespaces..."
-    for ns in $ALL_NAMESPACES; do
-        NS_STATE=$(kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE -o jsonpath="{.status.networkPolicies[?(@.namespace==\"$ns\")].state}" 2>/dev/null || echo "")
-        info_log "  Namespace $ns: state=$NS_STATE"
-    done
-else
-    info_log "No namespaces found in NetworkPolicy status"
-fi
-
-# ============================================================================
-# CLEANUP: Remove PRs and branches from GitHub (test isolation)
-# IMPORTANT: Cleanup is done AFTER all verifications are complete
-# IMPORTANT: Removes entire cluster_name directory
-# ============================================================================
-info_log "=========================================="
-info_log "Starting cleanup..."
-info_log "=========================================="
-cleanup_all_networkpolicy_test_artifacts "test-permissionbinder-networkpolicy" "$GITHUB_REPO" "DEV-cluster"
-
+# Cleanup handled by trap
 echo ""
 
 # ============================================================================

--- a/example/tests/test-implementations/test-49-networkpolicy---auto-merge-pr.sh
+++ b/example/tests/test-implementations/test-49-networkpolicy---auto-merge-pr.sh
@@ -1,10 +1,22 @@
 #!/bin/bash
 # Test 49: NetworkPolicy - Auto-Merge PR
+#
+# Self-contained under the first-owner-wins ownership gate (issues #45/#59):
+# own ConfigMap + dedicated namespace instead of the shared permission-config
+# ConfigMap already owned by the runner's baseline PermissionBinder.
+# NOTE: the auto-merge-label assertion stays red until operator bug #56 is
+# fixed (labels sent in the PR-create payload are silently dropped by GitHub).
 # Source common functions (SCRIPT_DIR should be set by parent script)
 if [ -z "$SCRIPT_DIR" ]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fi
 source "$SCRIPT_DIR/test-common.sh"
+
+BINDER_NAME="test-permissionbinder-networkpolicy"
+CONFIGMAP_NAME="np-test-config-49"
+# Dedicated namespace (prefix empty in legacy single-instance mode; name
+# contains "test-" so both cleanup sweeps catch it)
+AUTOMERGE_NS="${TEST_NS_PREFIX}np-test-49"
 
 # ============================================================================
 # ============================================================================
@@ -27,13 +39,13 @@ else
 fi
 
 # Setup: Create PermissionBinder with NetworkPolicy enabled and auto-merge enabled
-if ! kubectl_retry kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE >/dev/null 2>&1; then
+if ! kubectl_retry kubectl get permissionbinder $BINDER_NAME -n $NAMESPACE >/dev/null 2>&1; then
     info_log "Creating PermissionBinder with NetworkPolicy enabled and auto-merge enabled"
     cat <<EOF | kubectl apply -f - >/dev/null 2>&1
 apiVersion: permission.permission-binder.io/v1
 kind: PermissionBinder
 metadata:
-  name: test-permissionbinder-networkpolicy
+  name: $BINDER_NAME
   namespace: $NAMESPACE
 spec:
   prefixes:
@@ -41,7 +53,7 @@ spec:
   roleMapping:
     engineer: "edit"
     viewer: "view"
-  configMapName: "permission-config"
+  configMapName: "$CONFIGMAP_NAME"
   configMapNamespace: "$NAMESPACE"
   networkPolicy:
     enabled: true
@@ -69,17 +81,11 @@ spec:
 EOF
 fi
 
-# Update ConfigMap with test namespace
-cat <<EOF | kubectl apply -f - >/dev/null 2>&1
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: permission-config
-  namespace: $NAMESPACE
-data:
-  whitelist.txt: |
-    CN=COMPANY-K8S-test-automerge-engineer,OU=Openshift,DC=example,DC=com
-EOF
+# Own ConfigMap -> this CR is the first (and only) owner of $AUTOMERGE_NS
+if ! create_np_test_configmap "$CONFIGMAP_NAME" "$AUTOMERGE_NS"; then
+    fail_test "Could not create test ConfigMap $CONFIGMAP_NAME"
+    exit 1
+fi
 
 # Wait for reconciliation
 info_log "Waiting for PermissionBinder to process ConfigMap (5s)"
@@ -91,7 +97,7 @@ WAITED=0
 POLL_INTERVAL=2
 NAMESPACES_FOUND=""
 while [ $WAITED -lt $MAX_WAIT ]; do
-    NAMESPACES_FOUND=$(kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE -o jsonpath='{.status.networkPolicies[*].namespace}' 2>/dev/null || echo "")
+    NAMESPACES_FOUND=$(kubectl get permissionbinder $BINDER_NAME -n $NAMESPACE -o jsonpath='{.status.networkPolicies[*].namespace}' 2>/dev/null || echo "")
     if [ -n "$NAMESPACES_FOUND" ] && [ "$NAMESPACES_FOUND" != "" ]; then
         break
     fi
@@ -110,11 +116,11 @@ fi
 # VERIFICATION: Wait for PR creation and auto-merge
 # ============================================================================
 GITHUB_REPO="lukasz-bielinski/tests-network-policies"
-TEST_NAMESPACE="test-automerge"
+TEST_NAMESPACE="$AUTOMERGE_NS"
 PR_VERIFICATION_FAILED=0
 
 info_log "Waiting for PR to be created and auto-merged for $TEST_NAMESPACE (up to 180s)..."
-pr_number=$(wait_for_pr_in_status "test-permissionbinder-networkpolicy" "$TEST_NAMESPACE" 180)
+pr_number=$(wait_for_pr_in_status "$BINDER_NAME" "$TEST_NAMESPACE" 180)
 
 if [ -z "$pr_number" ] || [ "$pr_number" == "" ]; then
     fail_test "PR number not found for namespace $TEST_NAMESPACE after 180s"
@@ -124,7 +130,7 @@ fi
 pass_test "PR number found: $pr_number"
 
 # Get PR details from status
-pr_details=$(get_pr_from_status "test-permissionbinder-networkpolicy" "$TEST_NAMESPACE")
+pr_details=$(get_pr_from_status "$BINDER_NAME" "$TEST_NAMESPACE")
 parse_pr_details() {
     local data="$1"
     IFS='|' read -r pr_num pr_url pr_branch pr_state <<< "$data"
@@ -229,7 +235,7 @@ info_log "Cleaning up test artifacts..."
 info_log "=========================================="
 
 # Cleanup files from main branch (PR was merged)
-cleanup_networkpolicy_test_artifacts "test-permissionbinder-networkpolicy" "$TEST_NAMESPACE" "$GITHUB_REPO"
+cleanup_networkpolicy_test_artifacts "$BINDER_NAME" "$TEST_NAMESPACE" "$GITHUB_REPO"
 
 # Final cleanup: Remove entire cluster directory
 info_log "Final cleanup: Removing entire DEV-cluster directory..."

--- a/example/tests/test-implementations/test-50-networkpolicy---metrics-verification.sh
+++ b/example/tests/test-implementations/test-50-networkpolicy---metrics-verification.sh
@@ -1,10 +1,20 @@
 #!/bin/bash
 # Test 50: NetworkPolicy - Metrics Verification
+#
+# Self-contained under the first-owner-wins ownership gate (issues #45/#59):
+# own ConfigMap + dedicated namespace instead of the shared permission-config
+# ConfigMap already owned by the runner's baseline PermissionBinder.
 # Source common functions
 if [ -z "$SCRIPT_DIR" ]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fi
 source "$SCRIPT_DIR/test-common.sh"
+
+BINDER_NAME="test-permissionbinder-networkpolicy"
+CONFIGMAP_NAME="np-test-config-50"
+# Dedicated namespace (prefix empty in legacy single-instance mode; name
+# contains "test-" so both cleanup sweeps catch it)
+METRICS_NS="${TEST_NS_PREFIX}np-test-50"
 
 # ============================================================================
 # ============================================================================
@@ -25,13 +35,13 @@ if ! kubectl_retry kubectl get secret github-gitops-credentials -n $NAMESPACE >/
 fi
 
 # Setup: Create PermissionBinder with NetworkPolicy enabled
-if ! kubectl_retry kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE >/dev/null 2>&1; then
+if ! kubectl_retry kubectl get permissionbinder $BINDER_NAME -n $NAMESPACE >/dev/null 2>&1; then
     info_log "Creating PermissionBinder with NetworkPolicy enabled"
     cat <<EOF | kubectl apply -f - >/dev/null 2>&1
 apiVersion: permission.permission-binder.io/v1
 kind: PermissionBinder
 metadata:
-  name: test-permissionbinder-networkpolicy
+  name: $BINDER_NAME
   namespace: $NAMESPACE
 spec:
   prefixes:
@@ -39,7 +49,7 @@ spec:
   roleMapping:
     engineer: "edit"
     viewer: "view"
-  configMapName: "permission-config"
+  configMapName: "$CONFIGMAP_NAME"
   configMapNamespace: "$NAMESPACE"
   networkPolicy:
     enabled: true
@@ -78,7 +88,7 @@ fi
 
 # Get initial metric values
 info_log "Getting initial metric values..."
-INITIAL_PR_CREATED=$(curl -s http://localhost:$METRICS_PORT/metrics 2>/dev/null | grep 'permission_binder_networkpolicy_prs_created_total' | grep 'cluster="DEV-cluster"' | grep 'namespace="test-metrics"' | awk '{print $2}' | head -1 || echo "0")
+INITIAL_PR_CREATED=$(curl -s http://localhost:$METRICS_PORT/metrics 2>/dev/null | grep 'permission_binder_networkpolicy_prs_created_total' | grep 'cluster="DEV-cluster"' | grep "namespace=\"$METRICS_NS\"" | awk '{print $2}' | head -1 || echo "0")
 INITIAL_PR_ERRORS=$(curl -s http://localhost:$METRICS_PORT/metrics 2>/dev/null | grep 'permission_binder_networkpolicy_pr_creation_errors_total' | grep 'cluster="DEV-cluster"' | awk '{print $2}' | head -1 || echo "0")
 INITIAL_TEMPLATE_ERRORS=$(curl -s http://localhost:$METRICS_PORT/metrics 2>/dev/null | grep 'permission_binder_networkpolicy_template_validation_errors_total' | grep 'cluster="DEV-cluster"' | awk '{print $2}' | head -1 || echo "0")
 
@@ -87,17 +97,11 @@ info_log "  PRs Created: $INITIAL_PR_CREATED"
 info_log "  PR Errors: $INITIAL_PR_ERRORS"
 info_log "  Template Errors: $INITIAL_TEMPLATE_ERRORS"
 
-# Create ConfigMap with test namespace
-cat <<EOF | kubectl apply -f - >/dev/null 2>&1
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: permission-config
-  namespace: $NAMESPACE
-data:
-  whitelist.txt: |
-    CN=COMPANY-K8S-test-metrics-engineer,OU=Openshift,DC=example,DC=com
-EOF
+# Own ConfigMap -> this CR is the first (and only) owner of $METRICS_NS
+if ! create_np_test_configmap "$CONFIGMAP_NAME" "$METRICS_NS"; then
+    fail_test "Could not create test ConfigMap $CONFIGMAP_NAME"
+    exit 1
+fi
 
 # Wait for reconciliation and PR creation
 info_log "Waiting for reconciliation and PR creation (30s)..."
@@ -105,7 +109,7 @@ sleep 30
 
 # Get final metric values
 info_log "Getting final metric values..."
-FINAL_PR_CREATED=$(curl -s http://localhost:$METRICS_PORT/metrics 2>/dev/null | grep 'permission_binder_networkpolicy_prs_created_total' | grep 'cluster="DEV-cluster"' | grep 'namespace="test-metrics"' | awk '{print $2}' | head -1 || echo "0")
+FINAL_PR_CREATED=$(curl -s http://localhost:$METRICS_PORT/metrics 2>/dev/null | grep 'permission_binder_networkpolicy_prs_created_total' | grep 'cluster="DEV-cluster"' | grep "namespace=\"$METRICS_NS\"" | awk '{print $2}' | head -1 || echo "0")
 FINAL_PR_ERRORS=$(curl -s http://localhost:$METRICS_PORT/metrics 2>/dev/null | grep 'permission_binder_networkpolicy_pr_creation_errors_total' | grep 'cluster="DEV-cluster"' | awk '{print $2}' | head -1 || echo "0")
 FINAL_TEMPLATE_ERRORS=$(curl -s http://localhost:$METRICS_PORT/metrics 2>/dev/null | grep 'permission_binder_networkpolicy_template_validation_errors_total' | grep 'cluster="DEV-cluster"' | awk '{print $2}' | head -1 || echo "0")
 
@@ -120,7 +124,7 @@ METRICS_VERIFICATION_FAILED=0
 # Check permission_binder_networkpolicy_prs_created_total
 if [ -n "$FINAL_PR_CREATED" ] && [ "$FINAL_PR_CREATED" != "0" ]; then
     # Check if metric exists with correct labels
-    METRIC_EXISTS=$(curl -s http://localhost:$METRICS_PORT/metrics 2>/dev/null | grep -c 'permission_binder_networkpolicy_prs_created_total.*cluster="DEV-cluster".*namespace="test-metrics".*variant="new"' || echo "0")
+    METRIC_EXISTS=$(curl -s http://localhost:$METRICS_PORT/metrics 2>/dev/null | grep -c "permission_binder_networkpolicy_prs_created_total.*cluster=\"DEV-cluster\".*namespace=\"$METRICS_NS\".*variant=\"new\"" || echo "0")
     if [ "$METRIC_EXISTS" -gt 0 ]; then
         pass_test "permission_binder_networkpolicy_prs_created_total metric exists with correct labels"
     else
@@ -162,7 +166,7 @@ fi
 
 # Cleanup test artifacts
 GITHUB_REPO="lukasz-bielinski/tests-network-policies"
-cleanup_networkpolicy_test_artifacts "test-permissionbinder-networkpolicy" "test-metrics" "$GITHUB_REPO"
+cleanup_networkpolicy_test_artifacts "$BINDER_NAME" "$METRICS_NS" "$GITHUB_REPO"
 cleanup_networkpolicy_files_from_repo "$GITHUB_REPO" "" "DEV-cluster"
 
 # Final test result

--- a/example/tests/test-implementations/test-51-networkpolicy---rate-limiting-handling.sh
+++ b/example/tests/test-implementations/test-51-networkpolicy---rate-limiting-handling.sh
@@ -1,10 +1,20 @@
 #!/bin/bash
 # Test 51: NetworkPolicy - Rate Limiting Handling
+#
+# Self-contained under the first-owner-wins ownership gate (issues #45/#59):
+# own ConfigMap + dedicated namespaces instead of the shared permission-config
+# ConfigMap already owned by the runner's baseline PermissionBinder.
 # Source common functions
 if [ -z "$SCRIPT_DIR" ]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fi
 source "$SCRIPT_DIR/test-common.sh"
+
+BINDER_NAME="test-permissionbinder-networkpolicy"
+CONFIGMAP_NAME="np-test-config-51"
+# Dedicated namespace base (prefix empty in legacy single-instance mode; names
+# contain "test-" so both cleanup sweeps catch them)
+RATELIMIT_BASE="${TEST_NS_PREFIX}np-test-51-r"
 
 # ============================================================================
 # ============================================================================
@@ -29,13 +39,13 @@ if ! kubectl_retry kubectl get secret github-gitops-credentials -n $NAMESPACE >/
 fi
 
 # Setup: Create PermissionBinder with NetworkPolicy enabled
-if ! kubectl_retry kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE >/dev/null 2>&1; then
+if ! kubectl_retry kubectl get permissionbinder $BINDER_NAME -n $NAMESPACE >/dev/null 2>&1; then
     info_log "Creating PermissionBinder with NetworkPolicy enabled"
     cat <<EOF | kubectl apply -f - >/dev/null 2>&1
 apiVersion: permission.permission-binder.io/v1
 kind: PermissionBinder
 metadata:
-  name: test-permissionbinder-networkpolicy
+  name: $BINDER_NAME
   namespace: $NAMESPACE
 spec:
   prefixes:
@@ -43,7 +53,7 @@ spec:
   roleMapping:
     engineer: "edit"
     viewer: "view"
-  configMapName: "permission-config"
+  configMapName: "$CONFIGMAP_NAME"
   configMapNamespace: "$NAMESPACE"
   networkPolicy:
     enabled: true
@@ -81,16 +91,7 @@ fi
 # (Note: This may not actually trigger rate limit, but tests error handling)
 info_log "Creating multiple namespaces rapidly to test rate limit handling..."
 for i in {1..5}; do
-    cat <<EOF | kubectl apply -f - >/dev/null 2>&1
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: permission-config
-  namespace: $NAMESPACE
-data:
-  whitelist.txt: |
-    CN=COMPANY-K8S-test-ratelimit-$i-engineer,OU=Openshift,DC=example,DC=com
-EOF
+    create_np_test_configmap "$CONFIGMAP_NAME" "${RATELIMIT_BASE}$i" || true
     sleep 1
 done
 
@@ -129,7 +130,7 @@ else
 fi
 
 # Verify operator continues processing other namespaces
-NAMESPACES_PROCESSED=$(kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE -o jsonpath='{.status.networkPolicies[*].namespace}' 2>/dev/null | wc -w || echo "0")
+NAMESPACES_PROCESSED=$(kubectl get permissionbinder $BINDER_NAME -n $NAMESPACE -o jsonpath='{.status.networkPolicies[*].namespace}' 2>/dev/null | wc -w || echo "0")
 if [ "$NAMESPACES_PROCESSED" -gt 0 ]; then
     pass_test "Operator continues processing namespaces (graceful degradation)"
 else
@@ -139,7 +140,7 @@ fi
 # Cleanup test artifacts
 GITHUB_REPO="lukasz-bielinski/tests-network-policies"
 for i in {1..5}; do
-    cleanup_networkpolicy_test_artifacts "test-permissionbinder-networkpolicy" "test-ratelimit-$i" "$GITHUB_REPO" 2>/dev/null || true
+    cleanup_networkpolicy_test_artifacts "$BINDER_NAME" "${RATELIMIT_BASE}$i" "$GITHUB_REPO" 2>/dev/null || true
 done
 cleanup_networkpolicy_files_from_repo "$GITHUB_REPO" "" "DEV-cluster" 2>/dev/null || true
 

--- a/example/tests/test-implementations/test-52-networkpolicy---variant-c-backup-non-template.sh
+++ b/example/tests/test-implementations/test-52-networkpolicy---variant-c-backup-non-template.sh
@@ -1,10 +1,20 @@
 #!/bin/bash
 # Test 52: NetworkPolicy - Variant C (Backup Non-Template NetworkPolicy)
+#
+# Self-contained under the first-owner-wins ownership gate (issues #45/#59):
+# own ConfigMap + dedicated namespace instead of the shared permission-config
+# ConfigMap already owned by the runner's baseline PermissionBinder.
 # Source common functions
 if [ -z "$SCRIPT_DIR" ]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fi
 source "$SCRIPT_DIR/test-common.sh"
+
+BINDER_NAME="test-permissionbinder-networkpolicy"
+CONFIGMAP_NAME="np-test-config-52"
+# Dedicated namespace (prefix empty in legacy single-instance mode; name
+# contains "test-" so both cleanup sweeps catch it)
+VARIANT_NS="${TEST_NS_PREFIX}np-test-52-variant-c"
 
 # ============================================================================
 # ============================================================================
@@ -29,13 +39,13 @@ else
 fi
 
 # Setup: Create PermissionBinder with NetworkPolicy enabled and backupExisting: true
-if ! kubectl_retry kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE >/dev/null 2>&1; then
+if ! kubectl_retry kubectl get permissionbinder $BINDER_NAME -n $NAMESPACE >/dev/null 2>&1; then
     info_log "Creating PermissionBinder with NetworkPolicy enabled and backupExisting: true"
     cat <<EOF | kubectl apply -f - >/dev/null 2>&1
 apiVersion: permission.permission-binder.io/v1
 kind: PermissionBinder
 metadata:
-  name: test-permissionbinder-networkpolicy
+  name: $BINDER_NAME
   namespace: $NAMESPACE
 spec:
   prefixes:
@@ -43,7 +53,7 @@ spec:
   roleMapping:
     engineer: "edit"
     viewer: "view"
-  configMapName: "permission-config"
+  configMapName: "$CONFIGMAP_NAME"
   configMapNamespace: "$NAMESPACE"
   networkPolicy:
     enabled: true
@@ -72,8 +82,8 @@ EOF
 fi
 
 # Create namespace with existing NetworkPolicy WITHOUT template annotation (non-template policy)
-if ! kubectl get namespace test-variant-c-ns >/dev/null 2>&1; then
-    kubectl create namespace test-variant-c-ns >/dev/null 2>&1
+if ! kubectl get namespace $VARIANT_NS >/dev/null 2>&1; then
+    kubectl create namespace $VARIANT_NS >/dev/null 2>&1
 fi
 
 # Create existing NetworkPolicy WITHOUT template annotation (custom policy - Variant C)
@@ -82,7 +92,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: custom-policy
-  namespace: test-variant-c-ns
+  namespace: $VARIANT_NS
   # NO template annotation - this is a custom policy (Variant C)
 spec:
   podSelector:
@@ -100,35 +110,23 @@ spec:
       port: 8080
 EOF
 
-# Update ConfigMap to include test-variant-c-ns namespace
-cat <<EOF | kubectl apply -f - >/dev/null 2>&1
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: permission-config
-  namespace: $NAMESPACE
-data:
-  whitelist.txt: |
-    CN=COMPANY-K8S-test-app-engineer,OU=Openshift,DC=example,DC=com
-    CN=COMPANY-K8S-test-app-2-viewer,OU=Openshift,DC=example,DC=com
-    CN=COMPANY-K8S-test-variant-c-ns-engineer,OU=Openshift,DC=example,DC=com
-EOF
+# Own ConfigMap resolving to the dedicated variant-c namespace
+if ! create_np_test_configmap "$CONFIGMAP_NAME" "$VARIANT_NS"; then
+    fail_test "Could not create test ConfigMap $CONFIGMAP_NAME"
+    exit 1
+fi
 
 # Wait for reconciliation to process backup (increased to allow operator time to create PRs)
 info_log "Waiting for reconciliation to process backup (15s)"
 sleep 15
 
 # ============================================================================
-# VERIFICATION: Check PR for test-variant-c-ns namespace (main test objective)
-# NOTE: test-app and test-app-2 may be skipped by operator if they already have status
-#       from previous tests (operator optimization - skips already processed namespaces)
-#       The main objective of this test is to verify backup variant for test-variant-c-ns
+# VERIFICATION: Check PR for $VARIANT_NS namespace (main test objective)
 # ============================================================================
 
 GITHUB_REPO="lukasz-bielinski/tests-network-policies"
-# Main test objective: verify backup for test-variant-c-ns
-# Other namespaces (test-app, test-app-2) may be skipped if already processed
-MAIN_TEST_NAMESPACE="test-variant-c-ns"
+# Main test objective: verify backup for $VARIANT_NS
+MAIN_TEST_NAMESPACE="$VARIANT_NS"
 PR_VERIFICATION_FAILED=0
 
 # Function to verify PR for a namespace (reuse from test-44 pattern)
@@ -142,11 +140,11 @@ verify_pr_for_namespace() {
     
     # Wait for PR to be created and get PR number from status
     info_log "Waiting for PR to be created for $namespace (polling every 2s, up to 120s)..."
-    pr_number=$(wait_for_pr_in_status "test-permissionbinder-networkpolicy" "$namespace" 120)
+    pr_number=$(wait_for_pr_in_status "$BINDER_NAME" "$namespace" 120)
     
     # If PR number not found, check if PR state indicates it was merged (may need to get PR from GitHub)
     if [ -z "$pr_number" ] || [ "$pr_number" == "" ]; then
-        local pr_state=$(kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE -o jsonpath="{.status.networkPolicies[?(@.namespace==\"$namespace\")].state}" 2>/dev/null || echo "")
+        local pr_state=$(kubectl get permissionbinder $BINDER_NAME -n $NAMESPACE -o jsonpath="{.status.networkPolicies[?(@.namespace==\"$namespace\")].state}" 2>/dev/null || echo "")
         if [ "$pr_state" == "pr-merged" ] || [ "$pr_state" == "pr-pending" ]; then
             info_log "PR state found: $pr_state, but PR number missing. Checking GitHub for recent PRs..."
             if command -v gh &> /dev/null; then
@@ -167,7 +165,7 @@ verify_pr_for_namespace() {
     pass_test "PR number found for $namespace: $pr_number"
     
     # Get PR details from status
-    local pr_details=$(get_pr_from_status "test-permissionbinder-networkpolicy" "$namespace")
+    local pr_details=$(get_pr_from_status "$BINDER_NAME" "$namespace")
     local pr_num pr_url pr_branch pr_state
     IFS='|' read -r pr_num pr_url pr_branch pr_state <<< "$pr_details"
     
@@ -206,8 +204,8 @@ verify_pr_for_namespace() {
             PR_VERIFICATION_FAILED=1
         fi
         
-        # Special verification for test-variant-c-ns (backup variant)
-        if [ "$namespace" == "test-variant-c-ns" ]; then
+        # Special verification for $VARIANT_NS (backup variant)
+        if [ "$namespace" == "$VARIANT_NS" ]; then
             if echo "$pr_title" | grep -qi "backup"; then
                 pass_test "PR title indicates backup variant"
             else
@@ -216,7 +214,7 @@ verify_pr_for_namespace() {
             
             # Verify PR contains backup files
             info_log "Verifying backup PR files..."
-            local expected_files="networkpolicies/DEV-cluster/test-variant-c-ns/custom-policy.yaml networkpolicies/DEV-cluster/kustomization.yaml"
+            local expected_files="networkpolicies/DEV-cluster/$VARIANT_NS/custom-policy.yaml networkpolicies/DEV-cluster/kustomization.yaml"
             if verify_pr_files "$GITHUB_REPO" "$pr_number" "$expected_files"; then
                 pass_test "Backup PR contains expected files"
             else
@@ -231,7 +229,7 @@ verify_pr_for_namespace() {
     fi
     
     # Verify PR state in PermissionBinder status
-    local namespace_state=$(kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE -o jsonpath="{.status.networkPolicies[?(@.namespace==\"$namespace\")].state}" 2>/dev/null || echo "")
+    local namespace_state=$(kubectl get permissionbinder $BINDER_NAME -n $NAMESPACE -o jsonpath="{.status.networkPolicies[?(@.namespace==\"$namespace\")].state}" 2>/dev/null || echo "")
     if [ -n "$namespace_state" ]; then
         case "$namespace_state" in
             "pr-created"|"pr-pending"|"pr-merged")
@@ -248,40 +246,22 @@ verify_pr_for_namespace() {
     return 0
 }
 
-# Verify PR for main test namespace (test-variant-c-ns)
+# Verify PR for main test namespace ($VARIANT_NS)
 # This is the main objective: verify backup variant works
 if ! verify_pr_for_namespace "$MAIN_TEST_NAMESPACE"; then
     PR_VERIFICATION_FAILED=1
 fi
 
-# Optional: Check if other namespaces were processed or skipped
-# (operator may skip them if they already have status from previous tests)
-info_log "Checking status of other namespaces (may be skipped if already processed)..."
-for ns in "test-app" "test-app-2"; do
-    NS_STATE=$(kubectl get permissionbinder test-permissionbinder-networkpolicy -n $NAMESPACE -o jsonpath="{.status.networkPolicies[?(@.namespace==\"$ns\")].state}" 2>/dev/null || echo "")
-    if [ -n "$NS_STATE" ]; then
-        info_log "Namespace $ns has state: $NS_STATE (already processed - operator optimization)"
-    else
-        info_log "Namespace $ns not in status (may be skipped by operator if already processed)"
-    fi
-done
-
 # ============================================================================
 # CLEANUP: Remove PRs and branches from GitHub (test isolation)
 # IMPORTANT: Cleanup is done AFTER all GitHub verifications are complete
-# IMPORTANT: Cleanup ALL namespaces from ConfigMap and remove entire cluster directory
 # ============================================================================
 info_log "=========================================="
 info_log "All PR verifications completed. Starting cleanup..."
 info_log "=========================================="
 
-# Cleanup: Clean up all namespaces that might have been processed
-# (including test-app and test-app-2 if they were processed)
 info_log "Cleaning up test namespaces..."
-cleanup_networkpolicy_test_artifacts "test-permissionbinder-networkpolicy" "$MAIN_TEST_NAMESPACE" "$GITHUB_REPO"
-# Also cleanup test-app and test-app-2 if they exist (may have been processed)
-cleanup_networkpolicy_test_artifacts "test-permissionbinder-networkpolicy" "test-app" "$GITHUB_REPO" 2>/dev/null || true
-cleanup_networkpolicy_test_artifacts "test-permissionbinder-networkpolicy" "test-app-2" "$GITHUB_REPO" 2>/dev/null || true
+cleanup_networkpolicy_test_artifacts "$BINDER_NAME" "$MAIN_TEST_NAMESPACE" "$GITHUB_REPO"
 
 # Final cleanup: Remove entire cluster directory
 info_log "Final cleanup: Removing entire DEV-cluster directory..."
@@ -294,8 +274,8 @@ if [ $PR_VERIFICATION_FAILED -eq 1 ]; then
 fi
 
 # Cleanup Kubernetes resources (always, regardless of PR status)
-kubectl delete networkpolicy custom-policy -n test-variant-c-ns --ignore-not-found=true >/dev/null 2>&1
-kubectl delete namespace test-variant-c-ns --ignore-not-found=true >/dev/null 2>&1
+kubectl delete networkpolicy custom-policy -n $VARIANT_NS --ignore-not-found=true >/dev/null 2>&1
+kubectl delete namespace $VARIANT_NS --ignore-not-found=true >/dev/null 2>&1
 
 echo ""
 

--- a/example/tests/test-implementations/test-54-networkpolicy---pr-state-transitions.sh
+++ b/example/tests/test-implementations/test-54-networkpolicy---pr-state-transitions.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 # Test 54: NetworkPolicy - PR State Transitions
+#
+# The test-side flow is correct: reconciliationInterval=10s plus ConfigMap
+# nudges (the operator has NO timer-driven requeue, so reconciles only happen
+# on events). KNOWN EXPECTED FAILURE until the operator gains a
+# pending->merged refresh: as of v1.8.x no code path transitions a
+# pr-pending entry to pr-merged for an externally merged PR - the periodic
+# pass only processes entries already in pr-merged (drift/template/stale),
+# the event-driven pass skips namespaces with a pr-pending entry, and
+# pr-merged is only ever set at creation time by immediate auto-merge
+# (verified live + at code level in issue #59). The pr-merged assertion
+# below goes green as soon as that operator gap is fixed.
 # Source common functions
 if [ -z "$SCRIPT_DIR" ]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -14,7 +25,9 @@ echo "---------------------------------------------"
 
 BINDER_NAME="test-permissionbinder-networkpolicy-state"
 CONFIGMAP_NAME="permission-config-state"
-TEST_NAMESPACE="test-state-transitions"
+# Dedicated namespace (prefix empty in legacy single-instance mode; name
+# contains "test-" so both cleanup sweeps catch it)
+TEST_NAMESPACE="${TEST_NS_PREFIX}np-test-54"
 GITHUB_REPO="lukasz-bielinski/tests-network-policies"
 
 if ! command -v gh &> /dev/null; then
@@ -24,9 +37,12 @@ fi
 
 # Cleanup helper
 cleanup_resources() {
-    cleanup_networkpolicy_test_artifacts "$BINDER_NAME" "$TEST_NAMESPACE" "$GITHUB_REPO" 2>/dev/null || true
+    # Delete the PB first: with a 10s reconciliationInterval the operator
+    # could otherwise recreate artifacts between cleanup and PB removal
+    # (cleanup falls back to a branch-name lookup when the status is gone).
     kubectl delete permissionbinder "$BINDER_NAME" -n "$NAMESPACE" --ignore-not-found=true >/dev/null 2>&1
     kubectl delete configmap "$CONFIGMAP_NAME" -n "$NAMESPACE" --ignore-not-found=true >/dev/null 2>&1
+    cleanup_networkpolicy_test_artifacts "$BINDER_NAME" "$TEST_NAMESPACE" "$GITHUB_REPO" 2>/dev/null || true
 }
 
 trap cleanup_resources EXIT
@@ -46,9 +62,10 @@ if ! kubectl_retry kubectl get secret github-gitops-credentials -n "$NAMESPACE" 
 fi
 
 # ----------------------------------------------------------------------------
-# 2. Create PermissionBinder with NetworkPolicy auto-merge disabled
+# 2. Create PermissionBinder with NetworkPolicy auto-merge disabled and a
+#    short reconciliationInterval (PR-state refresh is periodic-only)
 # ----------------------------------------------------------------------------
-info_log "Creating PermissionBinder $BINDER_NAME"
+info_log "Creating PermissionBinder $BINDER_NAME with reconciliationInterval=10s"
 cat <<EOF | kubectl apply -f - >/dev/null 2>&1
 apiVersion: permission.permission-binder.io/v1
 kind: PermissionBinder
@@ -77,7 +94,7 @@ spec:
     autoMerge:
       enabled: false
     backupExisting: true
-    reconciliationInterval: "1h"
+    reconciliationInterval: "10s"
 EOF
 
 # ----------------------------------------------------------------------------
@@ -120,8 +137,21 @@ else
     pass_test "PR $PR_NUMBER merged via gh CLI"
 fi
 
-info_log "Waiting for operator to detect merged state (up to 120s)"
-if wait_for_pr_state "$BINDER_NAME" "$TEST_NAMESPACE" "pr-merged" 120; then
+# The merge happened on GitHub only - no Kubernetes event fires, so nudge
+# reconciliation with ConfigMap-annotation touches. NOTE: this makes the
+# refresh OBSERVABLE but cannot make it happen - the operator currently has
+# no pending->merged refresh path (see header); the assertion stays red
+# until that operator gap is fixed.
+info_log "Waiting for operator to detect merged state (up to 120s, nudging reconciliation every 15s)"
+MERGED_RECORDED=false
+for attempt in $(seq 1 8); do
+    touch_np_configmap "$CONFIGMAP_NAME"
+    if wait_for_pr_state "$BINDER_NAME" "$TEST_NAMESPACE" "pr-merged" 15; then
+        MERGED_RECORDED=true
+        break
+    fi
+done
+if [ "$MERGED_RECORDED" = "true" ]; then
     pass_test "PermissionBinder status transitioned to pr-merged"
 else
     CURRENT_STATE=$(kubectl get permissionbinder "$BINDER_NAME" -n "$NAMESPACE" -o jsonpath='{.status.networkPolicies[?(@.namespace=="'$TEST_NAMESPACE'")].state}' 2>/dev/null || echo "")

--- a/example/tests/test-implementations/test-55-networkpolicy---multiple-permissionbinders-validation.sh
+++ b/example/tests/test-implementations/test-55-networkpolicy---multiple-permissionbinders-validation.sh
@@ -16,6 +16,11 @@ BINDER_A="test-permissionbinder-networkpolicy-multi-a"
 BINDER_B="test-permissionbinder-networkpolicy-multi-b"
 CONFIGMAP_A="permission-config-multi-a"
 CONFIGMAP_B="permission-config-multi-b"
+# Dedicated namespaces (prefix empty in legacy single-instance mode; names
+# contain "test-" so both cleanup sweeps catch them - the previous unprefixed
+# multi-a/multi-b names matched NEITHER sweep and survived as orphans)
+NS_A="${TEST_NS_PREFIX}np-test-55-a"
+NS_B="${TEST_NS_PREFIX}np-test-55-b"
 GITHUB_REPO="lukasz-bielinski/tests-network-policies"
 METRICS_PORT=8080
 
@@ -23,6 +28,10 @@ METRICS_PORT=8080
 cleanup_resources() {
     kubectl delete permissionbinder "$BINDER_A" "$BINDER_B" -n "$NAMESPACE" --ignore-not-found=true >/dev/null 2>&1
     kubectl delete configmap "$CONFIGMAP_A" "$CONFIGMAP_B" -n "$NAMESPACE" --ignore-not-found=true >/dev/null 2>&1
+    # Both CRs create PRs for their namespaces (auto-merge off) - remove them
+    # from the fixture repo or the branches leak into later runs.
+    cleanup_networkpolicy_test_artifacts "$BINDER_A" "$NS_A" "$GITHUB_REPO" 2>/dev/null || true
+    cleanup_networkpolicy_test_artifacts "$BINDER_B" "$NS_B" "$GITHUB_REPO" 2>/dev/null || true
 }
 
 trap cleanup_resources EXIT
@@ -114,7 +123,7 @@ metadata:
   namespace: $NAMESPACE
 data:
   whitelist.txt: |
-    CN=COMPANY-K8S-multi-a-engineer,OU=Openshift,DC=example,DC=com
+    CN=COMPANY-K8S-$NS_A-engineer,OU=Openshift,DC=example,DC=com
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -123,7 +132,7 @@ metadata:
   namespace: $NAMESPACE
 data:
   whitelist.txt: |
-    CN=COMPANY-K8S-multi-b-engineer,OU=Openshift,DC=example,DC=com
+    CN=COMPANY-K8S-$NS_B-engineer,OU=Openshift,DC=example,DC=com
 EOF
 
 info_log "Waiting for reconciliation (20s)"

--- a/example/tests/test-implementations/test-56-networkpolicy---template-changes-detection.sh
+++ b/example/tests/test-implementations/test-56-networkpolicy---template-changes-detection.sh
@@ -24,7 +24,9 @@ fi
 
 BINDER_NAME="test-permissionbinder-networkpolicy-template"
 CONFIGMAP_NAME="permission-config-template"
-TEST_NAMESPACE="test-template-changes"
+# Dedicated namespace (prefix empty in legacy single-instance mode; name
+# contains "test-" so both cleanup sweeps catch it)
+TEST_NAMESPACE="${TEST_NS_PREFIX}np-test-56"
 GITHUB_REPO="lukasz-bielinski/tests-network-policies"
 TEMPLATE_PATH="networkpolicies/templates/deny-all-ingress.yaml"
 METRICS_PORT=8080
@@ -33,6 +35,12 @@ ORIGINAL_TEMPLATE_BASE64=""
 UPDATED_TEMPLATE_SHA=""
 
 cleanup_resources() {
+    # Delete the PB FIRST: with a 10s reconciliationInterval the operator
+    # would otherwise detect the template revert below as ANOTHER template
+    # change and open a fresh PR after the artifact cleanup already ran.
+    kubectl delete permissionbinder "$BINDER_NAME" -n "$NAMESPACE" --ignore-not-found=true >/dev/null 2>&1
+    kubectl delete configmap "$CONFIGMAP_NAME" -n "$NAMESPACE" --ignore-not-found=true >/dev/null 2>&1
+
     if [ -n "$UPDATED_TEMPLATE_SHA" ] && [ -n "$ORIGINAL_TEMPLATE_BASE64" ]; then
         info_log "Reverting template file to original content"
         np_gh api repos/"$GITHUB_REPO"/contents/"$TEMPLATE_PATH" \
@@ -43,8 +51,6 @@ cleanup_resources() {
     fi
 
     cleanup_networkpolicy_test_artifacts "$BINDER_NAME" "$TEST_NAMESPACE" "$GITHUB_REPO" 2>/dev/null || true
-    kubectl delete permissionbinder "$BINDER_NAME" -n "$NAMESPACE" --ignore-not-found=true >/dev/null 2>&1
-    kubectl delete configmap "$CONFIGMAP_NAME" -n "$NAMESPACE" --ignore-not-found=true >/dev/null 2>&1
 }
 
 trap cleanup_resources EXIT
@@ -123,13 +129,47 @@ if [ -z "$INITIAL_PR" ]; then
 fi
 pass_test "Initial PR created (number: $INITIAL_PR)"
 
-# Merge initial PR to simulate steady state
-if ! np_gh pr merge "$INITIAL_PR" --repo "$GITHUB_REPO" --merge --admin >/dev/null 2>&1; then
-    info_log "⚠️  Failed to merge initial PR automatically (may already be merged or checks failing)"
+# Merge the initial PR to reach steady state BEFORE mutating the template:
+# the operator (correctly) keeps at most ONE open PR per namespace, so a
+# template-change PR can only appear once the initial PR is closed/merged
+# AND the periodic reconciliation has recorded pr-merged (issue #59).
+info_log "Merging initial PR $INITIAL_PR (one-open-PR-per-namespace dedup requires it merged first)"
+if np_gh pr merge "$INITIAL_PR" --repo "$GITHUB_REPO" --merge --admin >/dev/null 2>&1; then
+    pass_test "Initial PR $INITIAL_PR merged via gh CLI"
+else
+    INITIAL_PR_STATE=$(np_gh pr view "$INITIAL_PR" --repo "$GITHUB_REPO" --json state --jq '.state' 2>/dev/null || echo "")
+    if [ "$INITIAL_PR_STATE" == "MERGED" ]; then
+        info_log "Initial PR $INITIAL_PR already merged"
+    else
+        fail_test "Could not merge initial PR $INITIAL_PR (state: ${INITIAL_PR_STATE:-unknown}); template-change PR would be deduplicated"
+        exit 1
+    fi
 fi
 
-info_log "Waiting for operator to record pr-merged (30s)"
-wait_for_pr_state "$BINDER_NAME" "$TEST_NAMESPACE" "pr-merged" 120 >/dev/null 2>&1 || true
+# The merge happened on GitHub only - no Kubernetes event fires, so nudge
+# reconciliation with ConfigMap-annotation touches (the operator has no
+# timer-driven requeue). KNOWN EXPECTED FAILURE until the operator gains a
+# pending->merged refresh: as of v1.8.x no code path transitions pr-pending
+# to pr-merged for an externally merged PR, and checkTemplateChanges only
+# processes pr-merged entries - so this gate fails fast HERE (with a precise
+# message) instead of failing later on a missing template-change PR. It goes
+# green as soon as that operator gap is fixed (issue #59).
+info_log "Waiting for operator to record pr-merged (up to 120s, nudging reconciliation every 15s)"
+MERGED_RECORDED=false
+for attempt in $(seq 1 8); do
+    touch_np_configmap "$CONFIGMAP_NAME"
+    if wait_for_pr_state "$BINDER_NAME" "$TEST_NAMESPACE" "pr-merged" 15; then
+        MERGED_RECORDED=true
+        break
+    fi
+done
+if [ "$MERGED_RECORDED" = "true" ]; then
+    pass_test "Operator recorded pr-merged for initial PR"
+else
+    CURRENT_STATE=$(kubectl get permissionbinder "$BINDER_NAME" -n "$NAMESPACE" -o jsonpath='{.status.networkPolicies[?(@.namespace=="'$TEST_NAMESPACE'")].state}' 2>/dev/null || echo "")
+    fail_test "Operator did not record pr-merged within 120s (current state: ${CURRENT_STATE:-unknown}); aborting before template mutation"
+    exit 1
+fi
 
 # ----------------------------------------------------------------------------
 # 4. Modify template file to trigger template change detection
@@ -169,12 +209,15 @@ info_log "Template updated, waiting for periodic reconciliation (30s)"
 sleep 30
 
 # ----------------------------------------------------------------------------
-# 5. Verify new PR created due to template change
+# 5. Verify new PR created due to template change. The template edit is a
+#    GitHub-only change (no Kubernetes event), so keep nudging reconciliation
+#    with ConfigMap-annotation touches while polling (issue #59).
 # ----------------------------------------------------------------------------
 NEW_PR=""
 MAX_WAIT=180
 WAITED=0
 while [ $WAITED -lt $MAX_WAIT ]; do
+    touch_np_configmap "$CONFIGMAP_NAME"
     NEW_PR=$(kubectl get permissionbinder "$BINDER_NAME" -n "$NAMESPACE" -o jsonpath='{.status.networkPolicies[?(@.namespace=="'$TEST_NAMESPACE'")].prNumber}' 2>/dev/null || echo "")
     if [ -n "$NEW_PR" ] && [ "$NEW_PR" != "$INITIAL_PR" ]; then
         break

--- a/example/tests/test-implementations/test-57-networkpolicy---read-only-repository-access.sh
+++ b/example/tests/test-implementations/test-57-networkpolicy---read-only-repository-access.sh
@@ -15,7 +15,9 @@ echo "-------------------------------------------------------------------"
 BINDER_NAME="test-permissionbinder-networkpolicy-readonly"
 CONFIGMAP_NAME="permission-config-readonly"
 SECRET_NAME="github-gitops-credentials-readonly"
-TEST_NAMESPACE="test-readonly"
+# Dedicated namespace (prefix empty in legacy single-instance mode; name
+# contains "test-" so both cleanup sweeps catch it)
+TEST_NAMESPACE="${TEST_NS_PREFIX}np-test-57"
 GITHUB_REPO="lukasz-bielinski/tests-network-policies"
 
 cleanup_resources() {

--- a/example/tests/test-implementations/test-58-networkpolicy---disabled-mode.sh
+++ b/example/tests/test-implementations/test-58-networkpolicy---disabled-mode.sh
@@ -14,7 +14,9 @@ echo "---------------------------------------"
 
 BINDER_NAME="test-permissionbinder-networkpolicy-disabled"
 CONFIGMAP_NAME="permission-config-disabled"
-TEST_NAMESPACE="test-disabled"
+# Dedicated namespace (prefix empty in legacy single-instance mode; name
+# contains "test-" so both cleanup sweeps catch it)
+TEST_NAMESPACE="${TEST_NS_PREFIX}np-test-58"
 
 cleanup_resources() {
     kubectl delete permissionbinder "$BINDER_NAME" -n "$NAMESPACE" --ignore-not-found=true >/dev/null 2>&1
@@ -73,7 +75,7 @@ else
 fi
 
 # Ensure metrics have no entries referencing namespace
-METRIC_MATCH=$(curl -s http://localhost:8080/metrics 2>/dev/null | grep "test-disabled" || true)
+METRIC_MATCH=$(curl -s http://localhost:8080/metrics 2>/dev/null | grep "$TEST_NAMESPACE" || true)
 if [ -z "$METRIC_MATCH" ]; then
     pass_test "No NetworkPolicy metrics emitted for disabled configuration"
 else

--- a/example/tests/test-implementations/test-59-networkpolicy---namespace-removal-cleanup.sh
+++ b/example/tests/test-implementations/test-59-networkpolicy---namespace-removal-cleanup.sh
@@ -15,8 +15,10 @@ echo "--------------------------------------------------"
 BINDER_NAME="test-permissionbinder-networkpolicy-removal"
 CONFIGMAP_NAME="permission-config-removal"
 GITHUB_REPO="lukasz-bielinski/tests-network-policies"
-NAMESPACE_A="test-remove-a"
-NAMESPACE_B="test-remove-b"
+# Dedicated namespaces (prefix empty in legacy single-instance mode; names
+# contain "test-" so both cleanup sweeps catch them)
+NAMESPACE_A="${TEST_NS_PREFIX}np-test-59-a"
+NAMESPACE_B="${TEST_NS_PREFIX}np-test-59-b"
 
 cleanup_resources() {
     cleanup_networkpolicy_test_artifacts "$BINDER_NAME" "$NAMESPACE_A" "$GITHUB_REPO" 2>/dev/null || true

--- a/example/tests/test-implementations/test-60-networkpolicy---high-frequency-reconciliation.sh
+++ b/example/tests/test-implementations/test-60-networkpolicy---high-frequency-reconciliation.sh
@@ -14,7 +14,9 @@ echo "-------------------------------------------------------"
 
 BINDER_NAME="test-permissionbinder-networkpolicy-hfreq"
 CONFIGMAP_NAME="permission-config-hfreq"
-BASE_NAMESPACE="test-hfreq"
+# Dedicated namespace base (prefix empty in legacy single-instance mode; names
+# contain "test-" so both cleanup sweeps catch them)
+BASE_NAMESPACE="${TEST_NS_PREFIX}np-test-60"
 GITHUB_REPO="lukasz-bielinski/tests-network-policies"
 
 cleanup_resources() {


### PR DESCRIPTION
Implements the full #59 rewrite; live-validated on k3s. Also **disproves #59's root-cause (b) hypothesis** and files the real operator gap as #60.

## What changed

1. **Self-containment (first-owner-wins safe)** — every NP test that shared the baseline `permission-config` (or hardcoded unprefixed namespaces) now provisions its own ConfigMap (`np-test-config-NN`, via new `create_np_test_configmap` helper) with `${TEST_NS_PREFIX}np-test-NN*` namespaces (swept by both cleanup modes). Also un-vacuated tests 46/47/48 (they previously asserted against a PermissionBinder that never exists under full isolation) and fixed test 55's orphan leak (`multi-a`/`multi-b` matched *neither* sweep).
2. **Flows 54/56** — 54: `reconciliationInterval: 10s` + ConfigMap-nudge loop (new `touch_np_configmap` helper — the operator has no timer-driven requeue); 56: the initial PR is now merged via `np_gh --admin` and `pr-merged` is required before the template mutation (fail-fast), trap deletes the PB before reverting the template (prevents a fresh leaked PR from the 10s reconciler).
3. **Cleanup ordering** — `cleanup-operator.sh` now verifies PermissionBinders are fully gone (poll → finalizer strip → last-resort strip covering Terminating namespaces) **before** deleting the operator; validated across ~10 live invocations with zero stuck namespaces.

## Live validation

- Instance mode (`INSTANCE=9`) NP series: **44, 45, 52, 59, 60 PASSED — first time this mode is green**; smoke of test 44 showed both namespaces receiving PRs (the exact #59(a) defect: previously `test-app-2` lost first-owner-wins 3/3).
- Test 49: exactly one red assertion (auto-merge label, operator bug #56) — everything else green, cleanup without 403s.
- Legacy spot check consistent; fixture repo left at 0 `networkpolicy/*` branches / 0 open PRs after every run.

## Known expected failures (documented in test headers)

- **54 & 56**: the operator has **no code path transitioning `pr-pending` → `pr-merged` for externally merged PRs** (periodic pass only processes `pr-merged` entries; no `RequeueAfter` anywhere) — #59's assumption that the 1h periodic refresh would cover this was wrong. Filed as **#60** with fix shape; both tests go green automatically once it lands.
- **49**: label assertion red until #56.
- **53**: untouched; needs a post-#57 operator image.

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)