### PR TITLE
ci: add Tests workflow running unit and envtest suites on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,48 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: operator/go.mod
+          cache-dependency-path: operator/go.sum
+
+      - name: Run unit and envtest suites
+        working-directory: operator
+        run: make test
+
+      - name: Check for uncommitted generated changes
+        run: |
+          # make test runs manifests/generate/fmt; any resulting diff means
+          # generated files or formatting were not committed
+          git diff --exit-code || {
+            echo "::error::make test modified files - run 'make test' locally and commit the changes"
+            exit 1
+          }
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: coverage
+          path: operator/cover.out
+          if-no-files-found: ignore


### PR DESCRIPTION
## Why

No CI job on `pull_request` runs `go test` today: the only workflow (`docker-build-push.yml`) does a docker build (`push: false` on PRs) plus a Trivy fs scan, and the Dockerfile itself only runs `go build`. Green checks on a PR therefore prove the production code compiles — nothing about the test suite. This gap surfaced while reviewing #62: a dependency bump could merge "green" with genuinely red tests.

## What

Adds `.github/workflows/test.yml`:

- runs `make test` (unit + envtest via setup-envtest, e2e excluded by the Makefile's own `grep -v /e2e`) on every PR and push to `main`, plus `workflow_dispatch`
- Go version taken from `operator/go.mod` (`go-version-file`), module cache keyed on `operator/go.sum`
- fails if `make test` (manifests/generate/fmt) leaves uncommitted drift in the tree
- uploads `cover.out` as a coverage artifact
- minimal permissions (`contents: read`), 25 min timeout

## Verification

The Tests workflow triggers on this PR itself — its run below is the proof. Expected result matches the local run on current deps: **605 passed / 0 failed / 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
