### PR TITLE
test: bump envtest to 1.37.0 / setup-envtest release-0.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 📊 Observability
 - `permission_binder_networkpolicy_git_operations_total` (clone/push by outcome) is now actually registered with the metrics registry — it was incremented but never exported, so it could not appear on `/metrics` (#54).
 
+### 🔧 Improvements
+- **envtest 1.37.0 / setup-envtest release-0.25** (#66): the unit + envtest suite now runs against a Kubernetes 1.37 apiserver, matching the controller-runtime v0.25.0 / k8s.io v0.37.0 stack from #64 (`ENVTEST_K8S_VERSION`, `ENVTEST_VERSION`, and the hardcoded `BinaryAssetsDirectory` fallbacks in `suite_test.go` / `status_poison_regression_test.go`).
+
 ## [1.8.0] - 2026-08-24
 
 ### 🚀 Highlights

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -52,7 +52,7 @@ OPERATOR_SDK_VERSION ?= unknown
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.36.2
+ENVTEST_K8S_VERSION = 1.37.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -247,7 +247,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.17.0
-ENVTEST_VERSION ?= release-0.24
+ENVTEST_VERSION ?= release-0.25
 GOLANGCI_LINT_VERSION ?= v1.59.1
 
 .PHONY: kustomize

--- a/operator/internal/controller/status_poison_regression_test.go
+++ b/operator/internal/controller/status_poison_regression_test.go
@@ -112,7 +112,7 @@ func startPoisonEnv(t *testing.T, wrapClient func(client.Client) client.Client) 
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.36.2-%s-%s", goruntime.GOOS, goruntime.GOARCH)),
+			fmt.Sprintf("1.37.0-%s-%s", goruntime.GOOS, goruntime.GOARCH)),
 	}
 	cfg, err := env.Start()
 	if err != nil {

--- a/operator/internal/controller/suite_test.go
+++ b/operator/internal/controller/suite_test.go
@@ -69,7 +69,7 @@ var _ = BeforeSuite(func() {
 		// Note that you must have the required binaries setup under the bin directory to perform
 		// the tests directly. When we run make test it will be setup and used automatically.
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.36.2-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("1.37.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
 	}
 
 	var err error


### PR DESCRIPTION
Closes #66.

## What

Aligns the envtest harness with the controller-runtime v0.25.0 / k8s.io v0.37.0 stack merged in #64:

- `operator/Makefile`: `ENVTEST_K8S_VERSION` 1.36.2 → **1.37.0**, `ENVTEST_VERSION` release-0.24 → **release-0.25**
- `operator/internal/controller/suite_test.go` and `status_poison_regression_test.go`: hardcoded `BinaryAssetsDirectory` fallback `bin/k8s/1.36.2-*` → `bin/k8s/1.37.0-*`
- `CHANGELOG.md`: entry under `[Unreleased]`

No production code changes.

## Verification (isolated clone, Go 1.27.1, linux/amd64)

- `setup-envtest@release-0.25` resolves and downloads `v1.37.0` assets (etcd, kube-apiserver, kubectl).
- `make test` end-to-end as CI runs it (manifests/generate/fmt/vet + envtest suite): green (`setup-envtest@release-0.25` downloaded, suite ran on `bin/k8s/1.37.0-linux-amd64`, all packages `ok`); working tree clean afterwards (no generate/fmt drift).
- Full non-e2e suite with `-v` on the 1.37.0 apiserver: **605 pass / 0 fail / 3 skip** — test-name set identical to the 1.36.2 run on current `main` (740e434).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
