### PR TITLE
docs(example): refresh operator image tags to 1.8.0

### DIFF
--- a/example/environments/production/kustomization.yaml
+++ b/example/environments/production/kustomization.yaml
@@ -26,7 +26,7 @@ patches:
     patch: |-
       - op: replace
         path: /spec/template/spec/containers/0/image
-        value: lukaszbielinski/permission-binder-operator:v1.2.1
+        value: lukaszbielinski/permission-binder-operator:1.8.0
       - op: replace
         path: /spec/replicas
         value: 2

--- a/example/environments/staging/kustomization.yaml
+++ b/example/environments/staging/kustomization.yaml
@@ -26,7 +26,7 @@ patches:
     patch: |-
       - op: replace
         path: /spec/template/spec/containers/0/image
-        value: lukaszbielinski/permission-binder-operator:v1.2.1
+        value: lukaszbielinski/permission-binder-operator:1.8.0
       - op: replace
         path: /spec/replicas
         value: 1

--- a/example/rhacs/QUICKSTART.md
+++ b/example/rhacs/QUICKSTART.md
@@ -207,7 +207,7 @@ oc logs deployment/admission-control -n rhacs-operator | tail -50
 cosign verify \
   --certificate-identity-regexp "https://github.com/lukasz-bielinski/permission-binder-operator" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  docker.io/lukaszbielinski/permission-binder-operator:1.5.0
+  docker.io/lukaszbielinski/permission-binder-operator:1.8.0
 
 # Check RHACS can reach Rekor
 oc exec -n rhacs-operator deployment/central -- curl -I https://rekor.sigstore.dev

--- a/example/rhacs/README.md
+++ b/example/rhacs/README.md
@@ -231,7 +231,7 @@ oc get configmap -n rhacs-operator
 cosign verify \
   --certificate-identity-regexp "https://github.com/lukasz-bielinski/permission-binder-operator" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  lukaszbielinski/permission-binder-operator:1.5.0
+  lukaszbielinski/permission-binder-operator:1.8.0
 
 # Check RHACS can reach Rekor
 oc exec -n rhacs-operator deployment/central -- curl -I https://rekor.sigstore.dev

--- a/example/rhacs/cosign-integration-config.yaml
+++ b/example/rhacs/cosign-integration-config.yaml
@@ -60,6 +60,6 @@ data:
     7. Click: Save
     
     To verify the integration works:
-    - Test image: docker.io/lukaszbielinski/permission-binder-operator:1.5.0
+    - Test image: docker.io/lukaszbielinski/permission-binder-operator:1.8.0
     - Should show "Signature Verified" in image details
 

--- a/example/rhacs/scripts/apply-cosign-integration.sh
+++ b/example/rhacs/scripts/apply-cosign-integration.sh
@@ -111,7 +111,7 @@ roxctl --endpoint "${ROX_ENDPOINT}" \
 # Test with permission-binder-operator image
 echo ""
 echo "🧪 Testing signature verification..."
-echo "Image: docker.io/lukaszbielinski/permission-binder-operator:1.4.0"
+echo "Image: docker.io/lukaszbielinski/permission-binder-operator:1.8.0"
 
 # Note: Image verification test via API would require more complex setup
 echo "✅ Setup complete!"

--- a/example/rhacs/scripts/verify-setup.sh
+++ b/example/rhacs/scripts/verify-setup.sh
@@ -150,12 +150,12 @@ echo "5. Testing Image Signature Verification"
 echo "════════════════════════════════════════════════════════════════════════════"
 
 if [ "$COSIGN_AVAILABLE" = true ]; then
-    echo "Testing Cosign signature for permission-binder-operator:1.4.0..."
+    echo "Testing Cosign signature for permission-binder-operator:1.8.0..."
     
     if cosign verify \
         --certificate-identity-regexp "https://github.com/lukasz-bielinski/permission-binder-operator" \
         --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-        docker.io/lukaszbielinski/permission-binder-operator:1.4.0 &>/dev/null; then
+        docker.io/lukaszbielinski/permission-binder-operator:1.8.0 &>/dev/null; then
         echo "✅ Image signature verification PASSED"
     else
         echo "❌ Image signature verification FAILED"

--- a/example/tests/README.md
+++ b/example/tests/README.md
@@ -142,7 +142,7 @@ kubectl apply -f deployment/operator-deployment.yaml -f deployment/servicemonito
 
 ### Test Fails During Deployment
 - Check `/tmp/deploy-<test_id>.log` for errors
-- Verify Docker image is available: `docker pull lukaszbielinski/permission-binder-operator:1.6.0-rc2`
+- Verify Docker image is available: `docker pull lukaszbielinski/permission-binder-operator:1.8.0`
 - Check operator pod logs: `kubectl logs -n permissions-binder-operator deployment/operator-controller-manager`
 
 ### Test Fails During Execution


### PR DESCRIPTION
Closes #74.

## What

Documentation/examples only — every hard-coded operator image tag under `example/` now points at **1.8.0**, the tag already used by `example/deployment/operator-deployment.yaml` and the README:

| File | Was |
|---|---|
| `example/environments/{staging,production}/kustomization.yaml` | `v1.2.1` (also wrong form — Docker Hub tags have no `v` prefix) |
| `example/rhacs/{README.md,QUICKSTART.md,cosign-integration-config.yaml}` | `1.5.0` |
| `example/rhacs/scripts/{verify-setup.sh,apply-cosign-integration.sh}` | `1.4.0` (found while grepping, beyond the six listed in the issue) |
| `example/tests/README.md` | `1.6.0-rc2` |

No changes under `operator/` or to CHANGELOG history entries (those reference the versions they were written for).

## Verification

- `grep -rnE 'permission-binder-operator:(v?[01]\.[0-7]\.[0-9]+|1\.6\.0-rc[0-9]*)' example README.md docs` → empty.
- `cosign verify --certificate-identity-regexp "https://github.com/lukasz-bielinski/permission-binder-operator" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" docker.io/lukaszbielinski/permission-binder-operator:1.8.0` → signature verified (cosign v3.1.3), so the RHACS examples still target a keyless-signed tag.
- `kubectl kustomize --load-restrictor LoadRestrictionsNone example/environments/{staging,production}` renders `image: lukaszbielinski/permission-binder-operator:1.8.0`. (Without the relaxed load restrictor both overlays already failed before this change — they pull `../../crd/*.yaml` from outside the overlay directory — that is pre-existing and out of scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
